### PR TITLE
Result editing update and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ This is a place for hosting unofficial Rubik's cube competitions, unofficial eve
   <img src="https://cubingcontests.com/api/cubing_contests_8.jpg" width="300"/>
 </div>
 
+## API for entering attempts
+
+Cubing Contests supports entering attempts using an external device or service. The API is mostly the same as the [WCA Live API](https://github.com/thewca/wca-live/wiki/Entering-attempts-with-external-devices), but the selection of the competitor is different. You can either use `registrantId`, which is the unique numerical ID of the competitor in the CC database, or `wcaId`, which, naturally, is a string representation of the number of pickles the competitor has eaten in the current year (non-case-sensitive).
+
+To get the API key, go to the edit page of the contest and click "Get Access Token". Keep in mind that you will not be able to retrieve the key again after leaving that screen. You will only be able to generate a new one, which will invalidate the old key.
+
 ## Deployment
 
 Please do **NOT** try to deploy your own instance until this project is ready for that (you will find instructions in this section).

--- a/client/app/admin/results/page.tsx
+++ b/client/app/admin/results/page.tsx
@@ -35,7 +35,8 @@ const ManageResultsPage = () => {
       <ErrorMessages errorMessages={errorMessages} />
 
       <p className="px-3">
-        Total submitted results:&nbsp;<b>{results.length}</b>&#8194;|&#8194;Unapproved:&nbsp;
+        Total submitted results:&nbsp;<b>{results.length === 100 ? '100+' : results.length}</b>
+        &#8194;|&#8194;Unapproved:&nbsp;
         <b>{results.filter((r) => r.unapproved).length}</b>
       </p>
 

--- a/client/app/competitions/[id]/page.tsx
+++ b/client/app/competitions/[id]/page.tsx
@@ -93,6 +93,17 @@ const ContestDetailsPage = async ({ params }: { params: { id: string } }) => {
             ) : contest.state === ContestState.Finished ? (
               <p className="mb-4">The results for this contest are currently being checked</p>
             ) : undefined}
+
+            {contest.type === ContestType.WcaComp && (
+              <p className="mb-4">
+                Unofficial events from {contest.name}. For official events see the official{' '}
+                <a href={`https://worldcubeassociation.org/competitions/${contest.competitionId}`}>
+                  WCA competition page
+                </a>
+                .
+              </p>
+            )}
+
             {contest.description && (
               <>
                 <p className="fw-bold">Description:</p>

--- a/client/app/competitions/[id]/page.tsx
+++ b/client/app/competitions/[id]/page.tsx
@@ -9,7 +9,7 @@ import MarkdownDescription from '@c/MarkdownDescription';
 import { IContest, IContestData } from '@sh/types';
 import { ContestState, ContestType } from '@sh/enums';
 import { getDateOnly } from '@sh/sharedFunctions';
-import { getFormattedDate, getFormattedCoords } from '~/helpers/utilityFunctions';
+import { getFormattedDate } from '~/helpers/utilityFunctions';
 
 const ContestDetailsPage = async ({ params }: { params: { id: string } }) => {
   const { payload } = await myFetch.get(`/competitions/${params.id}`, { revalidate: 0 });
@@ -27,6 +27,17 @@ const ContestDetailsPage = async ({ params }: { params: { id: string } }) => {
     contest.state < ContestState.Finished &&
     ((!contest.endDate && start.getTime() === startOfDayInLocalTZ.getTime()) ||
       (contest.endDate && start <= startOfDayInLocalTZ && new Date(contest.endDate) >= startOfDayInLocalTZ));
+
+  const getFormattedCoords = () => {
+    const latitude = (contest.latitudeMicrodegrees / 1000000).toFixed(6);
+    const longitude = (contest.longitudeMicrodegrees / 1000000).toFixed(6);
+
+    return (
+      <a href={`https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}&zoom=18`} target="_blank">
+        {latitude}, {longitude}
+      </a>
+    );
+  };
 
   return (
     <ContestLayout contest={contest} activeTab="details">
@@ -51,7 +62,7 @@ const ContestDetailsPage = async ({ params }: { params: { id: string } }) => {
             {contest.venue && <p className="mb-2">Venue:&#8194;{contest.venue}</p>}
             {contest.address && <p className="mb-2">Address:&#8194;{contest.address}</p>}
             {contest.latitudeMicrodegrees !== undefined && contest.longitudeMicrodegrees !== undefined && (
-              <p className="mb-2">Coordinates:&#8194;{getFormattedCoords(contest)}</p>
+              <p className="mb-2">Coordinates:&#8194;{getFormattedCoords()}</p>
             )}
             {contest.contact && (
               <p className="mb-2">

--- a/client/app/components/adminAndModerator/DataEntryScreen.tsx
+++ b/client/app/components/adminAndModerator/DataEntryScreen.tsx
@@ -175,6 +175,8 @@ const DataEntryScreen = ({
 
   const editResult = (result: IResult) => {
     if (isEditable) {
+      window.scrollTo(0, 0);
+
       const expectedAttempts = roundFormats.find((rf) => rf.value === round.format)?.attempts;
       // If the competitor did not make cutoff, fill the missing attempts with empty results
       const newAttempts = [

--- a/client/app/components/adminAndModerator/DataEntryScreen.tsx
+++ b/client/app/components/adminAndModerator/DataEntryScreen.tsx
@@ -74,6 +74,10 @@ const DataEntryScreen = ({
     document.getElementById('Competitor_1').focus();
   }, [round.roundId]);
 
+  useEffect(() => {
+    console.log(resultUnderEdit);
+  }, [resultUnderEdit]);
+
   useScrollToTopForNewMessage({ errorMessages, successMessage });
 
   //////////////////////////////////////////////////////////////////////////////
@@ -100,9 +104,10 @@ const DataEntryScreen = ({
         setErrorMessages,
         setSuccessMessage,
         async (newResultWithBestAndAvg) => {
-          let updatedRound: IRound, errors: string[];
           setLoadingId('submit_attempt_button');
+          let updatedRound: IRound, errors: string[];
 
+          console.log('test', resultUnderEdit);
           if (resultUnderEdit === null) {
             const { payload, errors: err } = await myFetch.post(`/results/${round.roundId}`, newResultWithBestAndAvg);
             updatedRound = payload;

--- a/client/app/components/adminAndModerator/ResultForm.tsx
+++ b/client/app/components/adminAndModerator/ResultForm.tsx
@@ -248,6 +248,7 @@ const ResultForm = ({
             options={rounds.map((el) => ({ label: roundTypes[el.roundTypeId].label, value: el.roundTypeId }))}
             selected={round.roundTypeId}
             setSelected={changeRound}
+            disabled={disableMainSelects}
           />
         )}
       </div>

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -123,11 +123,11 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
       competitors,
       setErrorMessages,
       setSuccessMessage,
-      async (newResultWithBestAndAverage) => {
+      async (newResultWithBestAndAvg) => {
         setLoadingId(approve ? 'approve_button' : 'submit_button');
 
         if (!resultId) {
-          const { errors } = await myFetch.post('/results', newResultWithBestAndAverage);
+          const { errors } = await myFetch.post('/results', newResultWithBestAndAvg);
 
           if (errors) {
             setErrorMessages(errors);
@@ -142,12 +142,12 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
           setLoadingId('');
         } else {
           const updateResultDto: IUpdateResultDto = {
-            date: newResultWithBestAndAverage.date,
-            unapproved: newResultWithBestAndAverage.unapproved,
-            personIds: newResultWithBestAndAverage.personIds,
-            attempts: newResultWithBestAndAverage.attempts,
-            videoLink: newResultWithBestAndAverage.videoLink,
-            discussionLink: newResultWithBestAndAverage.discussionLink,
+            date: newResultWithBestAndAvg.date,
+            unapproved: newResultWithBestAndAvg.unapproved,
+            personIds: newResultWithBestAndAvg.personIds,
+            attempts: newResultWithBestAndAvg.attempts,
+            videoLink: newResultWithBestAndAvg.videoLink,
+            discussionLink: newResultWithBestAndAvg.discussionLink,
           };
           const { errors } = await myFetch.patch(`/results/${resultId}`, updateResultDto);
 
@@ -221,7 +221,8 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
                 <b>ENTIRE</b> solve (including memorization, if applicable). The video date is used as proof of when the
                 solve was done, an earlier date cannot be used. Make sure that you can be identified from the provided
                 video; if your channel name is not your real name, please include your full name or WCA ID in the
-                description of the video. If you have any questions or suggestions, feel free to send an email to{' '}
+                description of the video. If you do not have a WCA ID, please contact the admins to have a competitor
+                profile created for you. If you have any questions or suggestions, feel free to send an email to{' '}
                 {C.contactEmail}.
               </p>
               <button type="button" className="btn btn-success btn-sm" onClick={() => setShowRules(!showRules)}>
@@ -261,7 +262,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
             recordPairs={recordPairs}
             loadingRecordPairs={fetchRecordPairsTimer !== null}
             recordTypes={submissionInfo.activeRecordTypes}
-            nextFocusTargetId="date"
+            nextFocusTargetId={!submissionInfo.result || submissionInfo.result.unapproved ? 'date' : 'video_link'}
             resetTrigger={resultFormResetTrigger}
             setErrorMessages={setErrorMessages}
             setSuccessMessage={setSuccessMessage}
@@ -279,7 +280,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
             title="Date (dd.mm.yyyy)"
             value={date}
             setValue={changeDate}
-            disabled={!submissionInfo.result.unapproved}
+            disabled={submissionInfo.result ? !submissionInfo.result.unapproved : false}
             nextFocusTargetId={videoUnavailable ? 'discussion_link' : 'video_link'}
           />
           <FormTextInput

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -143,19 +143,20 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
         } else {
           const updateResultDto: IUpdateResultDto = {
             date: newResultWithBestAndAvg.date,
-            unapproved: submissionInfo.result.unapproved,
             personIds: newResultWithBestAndAvg.personIds,
             attempts: newResultWithBestAndAvg.attempts,
             videoLink: newResultWithBestAndAvg.videoLink,
             discussionLink: newResultWithBestAndAvg.discussionLink,
           };
+          if (!approve) updateResultDto.unapproved = submissionInfo.result.unapproved;
+
           const { errors } = await myFetch.patch(`/results/${resultId}`, updateResultDto);
 
           if (errors) {
             setErrorMessages(errors);
             setLoadingId('');
           } else {
-            setSuccessMessage(approve ? 'Result approved' : 'Result updated');
+            setSuccessMessage(approve ? 'Result successfully approved' : 'Result successfully updated');
 
             setTimeout(() => {
               window.location.href = '/admin/results';

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -11,7 +11,7 @@ import FormDateInput from '@c/form/FormDateInput';
 import FormTextInput from '@c/form/FormTextInput';
 import Button from '@c/UI/Button';
 import CreatorDetails from '@c/CreatorDetails';
-import { IAttempt, IEvent, IPerson, IResult, IResultsSubmissionInfo } from '@sh/types';
+import { IAttempt, IEvent, IPerson, IResult, IResultsSubmissionInfo, IUpdateResultDto } from '@sh/types';
 import { RoundFormat } from '@sh/enums';
 import { roundFormats } from '@sh/roundFormats';
 import C from '@sh/constants';
@@ -87,7 +87,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
           setAttempts(result.attempts);
           setDate(new Date(result.date));
           setCompetitors(persons);
-          if (result.videoLink) setVideoLink(result.videoLink);
+          setVideoLink(result.videoLink);
           if (result.discussionLink) setDiscussionLink(result.discussionLink);
         }
       });
@@ -111,7 +111,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
       attempts,
       best: -1,
       average: -1,
-      videoLink: videoUnavailable ? undefined : videoLink,
+      videoLink: videoUnavailable ? '' : videoLink,
       discussionLink: discussionLink || undefined,
     };
 
@@ -141,7 +141,15 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
 
           setLoadingId('');
         } else {
-          const { errors } = await myFetch.patch(`/results/${resultId}`, newResultWithBestAndAverage);
+          const updateResultDto: IUpdateResultDto = {
+            date: newResultWithBestAndAverage.date,
+            unapproved: newResultWithBestAndAverage.unapproved,
+            personIds: newResultWithBestAndAverage.personIds,
+            attempts: newResultWithBestAndAverage.attempts,
+            videoLink: newResultWithBestAndAverage.videoLink,
+            discussionLink: newResultWithBestAndAverage.discussionLink,
+          };
+          const { errors } = await myFetch.patch(`/results/${resultId}`, updateResultDto);
 
           if (errors) {
             setErrorMessages(errors);
@@ -203,9 +211,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
         <div className="mt-3 mx-auto px-3 fs-6" style={{ maxWidth: '900px' }}>
           {resultId ? (
             <p>
-              Once you approve the attempt, the backend will remove future records that would have been cancelled by it.
-              If you are editing a result that has already been approved, the backend <b>WILL NOT</b> recalculate any
-              records.
+              Once you submit the attempt, the backend will remove future records that would have been cancelled by it.
             </p>
           ) : (
             <>
@@ -273,6 +279,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
             title="Date (dd.mm.yyyy)"
             value={date}
             setValue={changeDate}
+            disabled={!submissionInfo.result.unapproved}
             nextFocusTargetId={videoUnavailable ? 'discussion_link' : 'video_link'}
           />
           <FormTextInput

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -143,7 +143,7 @@ const ResultsSubmissionForm = ({ resultId }: { resultId?: string }) => {
         } else {
           const updateResultDto: IUpdateResultDto = {
             date: newResultWithBestAndAvg.date,
-            unapproved: newResultWithBestAndAvg.unapproved,
+            unapproved: submissionInfo.result.unapproved,
             personIds: newResultWithBestAndAvg.personIds,
             attempts: newResultWithBestAndAvg.attempts,
             videoLink: newResultWithBestAndAvg.videoLink,

--- a/client/app/components/form/FormDateInput.tsx
+++ b/client/app/components/form/FormDateInput.tsx
@@ -11,12 +11,14 @@ const FormDateInput = ({
   title,
   value,
   setValue,
+  disabled,
   nextFocusTargetId,
 }: {
   id?: string;
   title: string;
   value: Date | null | undefined; // null means the date is invalid; undefined means it's empty
   setValue: (val: Date | null | undefined) => void;
+  disabled?: boolean;
   nextFocusTargetId?: string;
 }) => {
   const [dateText, setDateText] = useState('');
@@ -159,6 +161,7 @@ const FormDateInput = ({
         onKeyDown={(e) => onKeyDown(e)}
         onFocus={() => changePosition()}
         onClick={(e: any) => setPosition(e.target.selectionStart)}
+        disabled={disabled}
         className={'form-control' + (value === null && dateText.length === 8 ? ' is-invalid' : '')}
       />
     </div>

--- a/client/app/components/form/FormEventSelect.tsx
+++ b/client/app/components/form/FormEventSelect.tsx
@@ -29,7 +29,7 @@ const FormEventSelect = ({
         className="form-select"
         value={eventId}
         onChange={(e) => setEventId(e.target.value)}
-        disabled={events.length === 0 || disabled}
+        disabled={disabled || !events.some((e) => e.eventId === eventId)}
       >
         {events.map((el: IEvent) => (
           <option key={el.eventId} value={el.eventId}>

--- a/client/helpers/utilityFunctions.ts
+++ b/client/helpers/utilityFunctions.ts
@@ -330,7 +330,7 @@ export const getWcaCompetitionDetails = async (competitionId: string): Promise<I
     startDate,
     endDate,
     organizers: [], // this is set below
-    description: `Unofficial events from ${wcaCompData.name}. For official events see the official [WCA competition page](https://worldcubeassociation.org/competitions/${competitionId}).`,
+    description: '',
     competitorLimit,
     events: [],
     // compDetails.schedule needs to be set by an admin manually

--- a/client/helpers/utilityFunctions.ts
+++ b/client/helpers/utilityFunctions.ts
@@ -4,13 +4,9 @@ import { format } from 'date-fns-tz';
 import myFetch from './myFetch';
 import { Color, ContestType, EventFormat, Role, RoundFormat } from '@sh/enums';
 import C from '@sh/constants';
-import { IAttempt, IContest, IContestDto, IEvent, IPerson, IResult, IRound } from '@sh/types';
+import { IAttempt, IContestDto, IEvent, IPerson, IResult, IRound } from '@sh/types';
 import { IUserInfo } from './interfaces/UserInfo';
 import { getBestAndAverage } from '@sh/sharedFunctions';
-
-export const getFormattedCoords = (comp: IContest): string => {
-  return `${(comp.latitudeMicrodegrees / 1000000).toFixed(6)}, ${(comp.longitudeMicrodegrees / 1000000).toFixed(6)}`;
-};
 
 export const getFormattedDate = (startDate: Date | string, endDate?: Date | string, timeZone = 'UTC'): string => {
   if (!startDate) throw new Error('Start date missing!');

--- a/client/shared_helpers/interfaces/Result.ts
+++ b/client/shared_helpers/interfaces/Result.ts
@@ -28,14 +28,23 @@ export interface IResult {
   average: number; // for FMC it's 100 times the mean (to avoid decimals)
   regionalSingleRecord?: string;
   regionalAverageRecord?: string;
-  videoLink?: string; // only used for submitted results
-  discussionLink?: string; // only used for submitted results
+  videoLink?: string; // required for submitted results (but admins may leave this empty)
+  discussionLink?: string; // only used for submitted results (still optional though)
   createdBy?: unknown; // user ID of the user who created the result (only used for submitted results)
 }
 
 export interface IFeResult extends IResult {
   event: IEvent;
   persons: IPerson[];
+}
+
+export interface IUpdateResultDto {
+  date: Date;
+  unapproved?: boolean;
+  personIds: number[];
+  attempts: IAttempt[];
+  videoLink?: string; // required for submitted results
+  discussionLink?: string; // only used for submitted results
 }
 
 export interface IRanking {
@@ -49,7 +58,7 @@ export interface IRanking {
   date: Date;
   contest?: IContest; // optional, because some results are submitted, so they have no contest
   attempts?: IAttempt[]; // only set for the average and mean rankings
-  videoLink?: string; // only admins are not required to fill this out
+  videoLink?: string;
   discussionLink?: string;
 }
 

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -49,6 +49,7 @@ export const compareAvgs = (a: IResult, b: IResult, noTieBreaker = false): numbe
 };
 
 // IMPORTANT: it is assumed that recordPairs is sorted by importance (i.e. first WR, then the CRs, then NR, then PR)
+// and includes unapproved results
 export const setResultRecords = (
   result: IResult,
   event: IEvent,
@@ -214,7 +215,7 @@ export const getBestAndAverage = (
   best = Math.min(...convertedAttempts);
   if (best === Infinity) best = -1; // if infinity, that means every attempt was DNF/DNS
 
-  if (!makesCutoff || attempts.filter((a) => a.result !== 0).length < expectedAttempts || expectedAttempts < 3) {
+  if (!makesCutoff || expectedAttempts < 3 || attempts.filter((a) => a.result !== 0).length < expectedAttempts) {
     average = 0;
   } else if (dnfDnsCount > 1 || (dnfDnsCount > 0 && format !== RoundFormat.Average)) {
     average = -1;

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -56,6 +56,7 @@ export const setResultRecords = (
   recordPairs: IRecordPair[],
   noConsoleLog = false,
 ): IResult => {
+  console.log(recordPairs);
   for (const recordPair of recordPairs) {
     // TO-DO: REMOVE HARD CODING TO WR!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     if (recordPair.wcaEquivalent === WcaRecordType.WR) {

--- a/client/shared_helpers/types.ts
+++ b/client/shared_helpers/types.ts
@@ -12,6 +12,7 @@ export type { IPerson, IPersonDto } from './interfaces/Person';
 export type { IRecordType } from './interfaces/RecordType';
 export type {
   IResult,
+  IUpdateResultDto,
   IFeResult,
   IAttempt,
   IRanking,

--- a/server/src/app-dto/enter-attempt.dto.ts
+++ b/server/src/app-dto/enter-attempt.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsNumberString, IsString, Min } from 'class-validator';
+import { IsInt, IsNotEmpty, IsNumberString, IsOptional, IsString, Min } from 'class-validator';
 
 export class EnterAttemptDto {
   @IsString()
@@ -13,9 +13,14 @@ export class EnterAttemptDto {
   @Min(1)
   roundNumber: string;
 
+  @IsOptional()
   @IsInt()
   @Min(1)
-  registrantId: number;
+  registrantId?: number;
+
+  @IsOptional()
+  @IsString()
+  wcaId?: string;
 
   @IsInt()
   @Min(1)

--- a/server/src/app-dto/enter-attempt.dto.ts
+++ b/server/src/app-dto/enter-attempt.dto.ts
@@ -10,6 +10,7 @@ export class EnterAttemptDto {
   eventId: string;
 
   @IsNumberString()
+  @Min(1)
   roundNumber: string;
 
   @IsInt()

--- a/server/src/helpers/messages.ts
+++ b/server/src/helpers/messages.ts
@@ -9,3 +9,6 @@ At least one lowercase letter
 At least one uppercase letter
 At least one number
 At least one special character`;
+export const DATE_VALIDATION_MSG = 'Please enter a valid date';
+export const VIDEO_LINK_VALIDATION_MSG = 'Please enter a valid video link';
+export const DISCUSSION_LINK_VALIDATION_MSG = 'Please enter a valid discussion link';

--- a/server/src/helpers/utilityFunctions.ts
+++ b/server/src/helpers/utilityFunctions.ts
@@ -44,39 +44,13 @@ export const setRankings = async (
   return sortedResults;
 };
 
-export const getBaseSinglesFilter = (
-  event: IEvent,
-  {
-    best,
-    unapproved,
-  }: {
-    best: any;
-    unapproved?: any;
-  } = {
-    best: { $gt: 0 },
-    unapproved: { $exists: false },
-  },
-) => {
+export const getBaseSinglesFilter = (event: IEvent, best: any = { $gt: 0 }) => {
   const output: any = { eventId: event.eventId, best };
-  if (unapproved !== undefined) output.unapproved = unapproved;
   return output;
 };
 
-export const getBaseAvgsFilter = (
-  event: IEvent,
-  {
-    average,
-    unapproved,
-  }: {
-    average: any;
-    unapproved?: any;
-  } = {
-    average: { $gt: 0 },
-    unapproved: { $exists: false },
-  },
-) => {
+export const getBaseAvgsFilter = (event: IEvent, average: any = { $gt: 0 }) => {
   const output: any = { eventId: event.eventId, average, attempts: { $size: getDefaultAverageAttempts(event) } };
-  if (unapproved !== undefined) output.unapproved = unapproved;
   return output;
 };
 

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -136,12 +136,13 @@ export class AuthService {
     contest: ContestDocument, // this must be populated
     { ignoreState = false }: { ignoreState: boolean } = { ignoreState: false },
   ) {
-    if (
-      !user.roles.includes(Role.Admin) &&
-      (!user.roles.includes(Role.Moderator) ||
-        !contest.organizers.some((el) => el.personId === user.personId) ||
-        (contest.state >= ContestState.Finished && !ignoreState))
-    ) {
+    const hasAccessRights =
+      user.roles.includes(Role.Admin) ||
+      (user.roles.includes(Role.Moderator) &&
+        contest.organizers.some((el) => el.personId === user.personId) &&
+        (contest.state < ContestState.Finished || ignoreState));
+
+    if (!hasAccessRights) {
       this.logger.log(`User ${user.username} denied access rights to contest ${contest.competitionId}`);
       throw new UnauthorizedException(NO_ACCESS_RIGHTS_MSG);
     }

--- a/server/src/modules/contests/contests.service.ts
+++ b/server/src/modules/contests/contests.service.ts
@@ -390,25 +390,20 @@ export class ContestsService {
     if (isAdmin && newState === ContestState.Published) {
       this.logger.log(`Publishing contest ${contest.competitionId}...`);
 
-      if (contest.participants < C.minCompetitorsForUnofficialCompsAndMeetups)
+      if (contest.participants < C.minCompetitorsForUnofficialCompsAndMeetups) {
         throw new BadRequestException(
           `A meetup or unofficial competition may not have fewer than ${C.minCompetitorsForUnofficialCompsAndMeetups} competitors`,
         );
-
-      try {
-        // Unset unapproved from the results so that they can be included in the rankings
-        await this.resultModel.updateMany({ competitionId: contest.competitionId }, { $unset: { unapproved: '' } });
-
-        await this.resultsService.resetRecordsCancelledByPublishedContest(contest.competitionId);
-
-        await this.emailService.sendEmail(
-          contestCreatorEmail,
-          `The results of <a href="${contestUrl}">${contest.name}</a> have been published and will now enter the rankings.`,
-          { subject: `Contest published: ${contest.shortName}` },
-        );
-      } catch (err) {
-        throw new InternalServerErrorException(`Error while publishing contest: ${err.message}`);
       }
+
+      // Unset unapproved from the results so that they can be included in the rankings
+      await this.resultModel.updateMany({ competitionId: contest.competitionId }, { $unset: { unapproved: '' } });
+
+      await this.emailService.sendEmail(
+        contestCreatorEmail,
+        `The results of <a href="${contestUrl}">${contest.name}</a> have been published and will now enter the rankings.`,
+        { subject: `Contest published: ${contest.shortName}` },
+      );
     }
 
     await this.saveContest(contest);

--- a/server/src/modules/contests/tests/contests.service.spec.ts
+++ b/server/src/modules/contests/tests/contests.service.spec.ts
@@ -17,7 +17,7 @@ import { RecordTypesServiceMock } from '@m/record-types/tests/mocks/record-types
 import { ResultsServiceMock } from '@m/results/tests/mocks/results.service';
 import { PersonsServiceMock } from '@m/persons/tests/mocks/persons.service';
 import { AuthServiceMock } from '@m/auth/tests/mocks/auth.service';
-import { CompetitionModelMock } from './mocks/contest.model';
+import { ContestModelMock } from './mocks/contest.model';
 import { RoundModelMock } from './mocks/round.model';
 import { ResultModelMock } from '@m/results/tests/mocks/result.model';
 
@@ -65,7 +65,7 @@ describe('ContestsService', () => {
         },
         {
           provide: getModelToken('Competition'),
-          useFactory: CompetitionModelMock,
+          useFactory: ContestModelMock,
         },
         {
           provide: getModelToken('Round'),

--- a/server/src/modules/contests/tests/mocks/contest.model.ts
+++ b/server/src/modules/contests/tests/mocks/contest.model.ts
@@ -1,10 +1,10 @@
 import { ContestDocument } from '~/src/models/contest.model';
-import { competitionsStub } from '../stubs/competitions.stub';
+import { contestsStub } from '../stubs/competitions.stub';
 
-export const CompetitionModelMock = (): any => ({
+export const ContestModelMock = (): any => ({
   tempOutput: undefined,
   find(query: any, selectObj: any) {
-    this.tempOutput = competitionsStub();
+    this.tempOutput = contestsStub();
 
     if (query?.countryIso2) {
       this.tempOutput = this.tempOutput.filter((el: ContestDocument) => el.countryIso2 === query.countryIso2);
@@ -33,7 +33,7 @@ export const CompetitionModelMock = (): any => ({
   },
   findOne(query: any) {
     if (query?.competitionId) {
-      this.tempOutput = competitionsStub().find((el: ContestDocument) => el.competitionId === query.competitionId);
+      this.tempOutput = contestsStub().find((el: ContestDocument) => el.competitionId === query.competitionId);
     }
 
     return this;

--- a/server/src/modules/contests/tests/mocks/round.model.ts
+++ b/server/src/modules/contests/tests/mocks/round.model.ts
@@ -1,6 +1,6 @@
 import { RoundDocument } from '~/src/models/round.model';
 import { IRound } from '@sh/types';
-import { competitionsStub } from '../stubs/competitions.stub';
+import { contestsStub } from '../stubs/competitions.stub';
 
 export const RoundModelMock = (): any => ({
   tempOutput: undefined,
@@ -18,7 +18,7 @@ export const RoundModelMock = (): any => ({
   findOne({ competitionId, roundId }: { competitionId: string; roundId: string }): RoundDocument {
     const eventId = roundId.split('-')[0];
 
-    this.tempOutput = competitionsStub()
+    this.tempOutput = contestsStub()
       .find((c) => c.competitionId === competitionId)
       .events.find((e) => e.event.eventId === eventId)
       .rounds.find((r) => r.roundId === roundId);

--- a/server/src/modules/contests/tests/stubs/competitions.stub.ts
+++ b/server/src/modules/contests/tests/stubs/competitions.stub.ts
@@ -4,7 +4,7 @@ import { ContestState, ContestType, RoundFormat, RoundType, WcaRecordType } from
 import { IRound } from '@sh/types';
 import { eventsSeed } from '~/src/seeds/events.seed';
 
-export const competitionsStub = (): ContestDocument[] => {
+export const contestsStub = (): ContestDocument[] => {
   return [
     {
       _id: new mongoose.Types.ObjectId('649d2a23675dfd951d5ff308'),

--- a/server/src/modules/events/events.service.ts
+++ b/server/src/modules/events/events.service.ts
@@ -108,7 +108,7 @@ export class EventsService {
       throw new InternalServerErrorException(err.message);
     }
 
-    if (!event) throw new NotFoundException(`Event with id ${eventId} not found`);
+    if (!event) throw new NotFoundException(`Event with ID ${eventId} not found`);
 
     return event;
   }

--- a/server/src/modules/persons/persons.service.ts
+++ b/server/src/modules/persons/persons.service.ts
@@ -83,11 +83,7 @@ export class PersonsService {
     if (contestEvents) {
       for (const compEvent of contestEvents) compRounds.push(...compEvent.rounds);
     } else {
-      try {
-        compRounds = await this.roundModel.find({ competitionId }).populate('results').exec();
-      } catch (err) {
-        throw new InternalServerErrorException('Error while searching for contest rounds');
-      }
+      compRounds = await this.roundModel.find({ competitionId }).populate('results').exec();
     }
 
     for (const round of compRounds) {
@@ -102,11 +98,7 @@ export class PersonsService {
   }
 
   async getPersonsTotal(): Promise<number> {
-    try {
-      return await this.personModel.countDocuments().exec();
-    } catch (err) {
-      throw new InternalServerErrorException(err.message);
-    }
+    return await this.personModel.countDocuments().exec();
   }
 
   async createPerson(createPersonDto: CreatePersonDto, user: IPartialUser): Promise<PersonDocument> {

--- a/server/src/modules/record-types/tests/mocks/record-types.service.ts
+++ b/server/src/modules/record-types/tests/mocks/record-types.service.ts
@@ -1,4 +1,10 @@
+import { WcaRecordType } from '@sh/enums';
+import { getBaseAvgsFilter, getBaseSinglesFilter } from '~/src/helpers/utilityFunctions';
 import { recordTypesStub } from '../stubs/record-types.stub';
+import { EventDocument } from '~/src/models/event.model';
+
+export const setEventSingleRecordsMock = jest.fn();
+export const setEventAvgRecordsMock = jest.fn();
 
 export const RecordTypesServiceMock = () => ({
   async getRecordTypes(query: any) {
@@ -9,5 +15,15 @@ export const RecordTypesServiceMock = () => ({
     }
 
     return tempRecordTypes;
+  },
+  async setEventSingleRecords(
+    event: EventDocument,
+    wcaEquiv: WcaRecordType,
+    queryFilter: any = getBaseSinglesFilter(event),
+  ) {
+    setEventSingleRecordsMock(event, wcaEquiv, queryFilter);
+  },
+  async setEventAvgRecords(event: EventDocument, wcaEquiv: WcaRecordType, queryFilter: any = getBaseAvgsFilter(event)) {
+    setEventAvgRecordsMock(event, wcaEquiv, queryFilter);
   },
 });

--- a/server/src/modules/results/dto/create-result.dto.ts
+++ b/server/src/modules/results/dto/create-result.dto.ts
@@ -7,7 +7,6 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
-  IsUrl,
   Min,
   ValidateNested,
   Max,
@@ -18,10 +17,11 @@ import {
 import { IAttempt, IResult } from '@sh/types';
 import { Type } from 'class-transformer';
 import C from '@sh/constants';
+import { DATE_VALIDATION_MSG } from '~/src/helpers/messages';
 
 // This is almost the same as HasNonDnfDnsResult in SubmitResultDto
 @ValidatorConstraint({ name: 'HasNonDnsResult', async: false })
-class HasNonDnsResult implements ValidatorConstraintInterface {
+export class HasNonDnsResult implements ValidatorConstraintInterface {
   validate(attempts: IAttempt[]) {
     return attempts.some((a) => a.result !== -2);
   }
@@ -41,12 +41,12 @@ export class CreateResultDto implements IResult {
   @IsNotEmpty()
   eventId: string;
 
-  @IsDateString({}, { message: 'Please enter a valid date' })
+  @IsDateString({}, { message: DATE_VALIDATION_MSG })
   date: Date;
 
   @IsOptional()
   @IsBoolean()
-  unapproved: boolean;
+  unapproved?: boolean;
 
   @ArrayMinSize(1)
   @IsInt({ each: true })
@@ -68,14 +68,6 @@ export class CreateResultDto implements IResult {
 
   @IsInt()
   average: number;
-
-  @IsOptional()
-  @IsUrl({}, { message: 'Please enter a valid video link' })
-  videoLink?: string;
-
-  @IsOptional()
-  @IsUrl({}, { message: 'Please enter a valid discussion link' })
-  discussionLink?: string;
 }
 
 export class AttemptDto implements IAttempt {

--- a/server/src/modules/results/dto/submit-result.dto.ts
+++ b/server/src/modules/results/dto/submit-result.dto.ts
@@ -1,14 +1,17 @@
-import { IAttempt, IResult } from '@sh/types';
+import { Type } from 'class-transformer';
 import { AttemptDto, CreateResultDto } from './create-result.dto';
 import {
   ArrayMaxSize,
   ArrayMinSize,
+  IsOptional,
+  IsUrl,
   Validate,
   ValidateNested,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IAttempt, IResult } from '@sh/types';
+import { DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from '~/src/helpers/messages';
 
 @ValidatorConstraint({ name: 'HasNonDnfDnsResult', async: false })
 class HasNonDnfDnsResult implements ValidatorConstraintInterface {
@@ -28,4 +31,11 @@ export class SubmitResultDto extends CreateResultDto implements IResult {
   @ValidateNested({ each: true })
   @Type(() => AttemptDto)
   attempts: IAttempt[];
+
+  @IsUrl({}, { message: VIDEO_LINK_VALIDATION_MSG })
+  videoLink: string;
+
+  @IsOptional()
+  @IsUrl({}, { message: DISCUSSION_LINK_VALIDATION_MSG })
+  discussionLink?: string;
 }

--- a/server/src/modules/results/dto/submit-result.dto.ts
+++ b/server/src/modules/results/dto/submit-result.dto.ts
@@ -14,20 +14,20 @@ import { IAttempt, IResult } from '@sh/types';
 import { DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from '~/src/helpers/messages';
 
 @ValidatorConstraint({ name: 'HasNonDnfDnsResult', async: false })
-class HasNonDnfDnsResult implements ValidatorConstraintInterface {
+class VideoBasedAttempt implements ValidatorConstraintInterface {
   validate(attempts: IAttempt[]) {
-    return attempts.some((a) => a.result > 0);
+    return attempts.some((a) => a.result > 0) && !attempts.some((a) => a.result === 0);
   }
 
   defaultMessage() {
-    return 'You cannot submit only DNF/DNS results';
+    return 'You cannot submit only DNF/DNS results, and you cannot submit empty attempts';
   }
 }
 
 export class SubmitResultDto extends CreateResultDto implements IResult {
   @ArrayMinSize(1)
   @ArrayMaxSize(5)
-  @Validate(HasNonDnfDnsResult)
+  @Validate(VideoBasedAttempt)
   @ValidateNested({ each: true })
   @Type(() => AttemptDto)
   attempts: IAttempt[];

--- a/server/src/modules/results/dto/update-result.dto.ts
+++ b/server/src/modules/results/dto/update-result.dto.ts
@@ -1,0 +1,42 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsBoolean,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsUrl,
+  Validate,
+  ValidateNested,
+} from 'class-validator';
+import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from '~/src/helpers/messages';
+import { AttemptDto, HasNonDnsResult } from './create-result.dto';
+import { IAttempt, IUpdateResultDto } from '@sh/types';
+
+export class UpdateResultDto implements IUpdateResultDto {
+  @IsDateString({}, { message: DATE_VALIDATION_MSG })
+  date: Date;
+
+  @IsOptional()
+  @IsBoolean()
+  unapproved?: boolean;
+
+  @ArrayMinSize(1)
+  @IsInt({ each: true })
+  personIds: number[];
+
+  @ArrayMinSize(1)
+  @ArrayMaxSize(5)
+  @Validate(HasNonDnsResult)
+  @ValidateNested({ each: true })
+  @Type(() => AttemptDto)
+  attempts: IAttempt[];
+
+  @IsUrl({}, { message: VIDEO_LINK_VALIDATION_MSG })
+  videoLink: string;
+
+  @IsOptional()
+  @IsUrl({}, { message: DISCUSSION_LINK_VALIDATION_MSG })
+  discussionLink?: string;
+}

--- a/server/src/modules/results/dto/update-result.dto.ts
+++ b/server/src/modules/results/dto/update-result.dto.ts
@@ -33,8 +33,9 @@ export class UpdateResultDto implements IUpdateResultDto {
   @Type(() => AttemptDto)
   attempts: IAttempt[];
 
+  @IsOptional()
   @IsUrl({}, { message: VIDEO_LINK_VALIDATION_MSG })
-  videoLink: string;
+  videoLink?: string;
 
   @IsOptional()
   @IsUrl({}, { message: DISCUSSION_LINK_VALIDATION_MSG })

--- a/server/src/modules/results/results.controller.ts
+++ b/server/src/modules/results/results.controller.ts
@@ -20,6 +20,7 @@ import { RolesGuard } from '~/src/guards/roles.guard';
 import { Roles } from '~/src/helpers/roles.decorator';
 import { Role } from '@sh/enums';
 import { SubmitResultDto } from './dto/submit-result.dto';
+import { UpdateResultDto } from './dto/update-result.dto';
 import { LogType } from '~/src/helpers/enums';
 import { getDateOnly } from '@sh/sharedFunctions';
 
@@ -146,8 +147,11 @@ export class ResultsController {
   @Patch(':resultId')
   @UseGuards(AuthenticatedGuard, RolesGuard)
   @Roles(Role.Admin)
-  async editResult(@Param('resultId') resultId: string, @Body(new ValidationPipe()) updateResultDto: SubmitResultDto) {
-    this.logger.logAndSave(`Updating result with ID ${resultId}`, LogType.UpdateResult);
+  async editResult(@Param('resultId') resultId: string, @Body(new ValidationPipe()) updateResultDto: UpdateResultDto) {
+    this.logger.logAndSave(
+      `Updating result with ID ${resultId}: ${JSON.stringify(updateResultDto)}`,
+      LogType.UpdateResult,
+    );
 
     return await this.service.editResult(resultId, updateResultDto);
   }

--- a/server/src/modules/results/results.controller.ts
+++ b/server/src/modules/results/results.controller.ts
@@ -116,20 +116,6 @@ export class ResultsController {
     return await this.service.createResult(createResultDto, roundId, req.user);
   }
 
-  // DELETE /results/:competitionId/:resultId
-  @Delete(':competitionId/:resultId')
-  @UseGuards(AuthenticatedGuard, RolesGuard)
-  @Roles(Role.Admin, Role.Moderator)
-  async deleteContestResult(
-    @Param('competitionId') competitionId: string,
-    @Param('resultId') resultId: string,
-    @Request() req: any,
-  ) {
-    this.logger.logAndSave(`Deleting result with id ${resultId} from contest ${competitionId}`, LogType.DeleteResult);
-
-    return await this.service.deleteContestResult(resultId, competitionId, req.user);
-  }
-
   // POST /results
   @Post()
   @UseGuards(AuthenticatedGuard, RolesGuard)
@@ -147,12 +133,26 @@ export class ResultsController {
   @Patch(':resultId')
   @UseGuards(AuthenticatedGuard, RolesGuard)
   @Roles(Role.Admin)
-  async editResult(@Param('resultId') resultId: string, @Body(new ValidationPipe()) updateResultDto: UpdateResultDto) {
+  async editResult(
+    @Param('resultId') resultId: string,
+    @Body(new ValidationPipe()) updateResultDto: UpdateResultDto,
+    @Request() req: any,
+  ) {
     this.logger.logAndSave(
       `Updating result with ID ${resultId}: ${JSON.stringify(updateResultDto)}`,
       LogType.UpdateResult,
     );
 
-    return await this.service.editResult(resultId, updateResultDto);
+    return await this.service.editResult(resultId, updateResultDto, { user: req.user });
+  }
+
+  // DELETE /results/:resultId
+  @Delete(':resultId')
+  @UseGuards(AuthenticatedGuard, RolesGuard)
+  @Roles(Role.Admin, Role.Moderator)
+  async deleteContestResult(@Param('resultId') resultId: string, @Request() req: any) {
+    this.logger.logAndSave(`Deleting result with ID ${resultId}`, LogType.DeleteResult);
+
+    return await this.service.deleteResult(resultId, req.user);
   }
 }

--- a/server/src/modules/results/results.service.ts
+++ b/server/src/modules/results/results.service.ts
@@ -683,6 +683,8 @@ export class ResultsService {
     });
     setResultRecords(result, event, recordPairs);
 
+    console.log(result, updateResultDto);
+    // This is only relevant for video-based results
     if (result.unapproved && !updateResultDto.unapproved) {
       result.unapproved = undefined;
       await result.save();
@@ -690,7 +692,7 @@ export class ResultsService {
       await this.emailService.sendEmail(
         await this.usersService.getUserEmail({ _id: user._id }),
         `Your ${event.name} result has been approved. You can see it in the rankings <a href="${process.env.BASE_URL}/rankings/${event.eventId}/single">here</a>.`,
-        { subject: 'Result approved' },
+        { subject: 'Result Approved' },
       );
     } else {
       await result.save();

--- a/server/src/modules/results/results.service.ts
+++ b/server/src/modules/results/results.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,

--- a/server/src/modules/results/results.service.ts
+++ b/server/src/modules/results/results.service.ts
@@ -887,7 +887,7 @@ export class ResultsService {
           };
 
           if (singleGotWorse) {
-            const best: any = { $gt: mode === 'edit' ? previousBest : result.best };
+            const best: any = { $gt: 0 };
 
             // Make sure it's better than the record at the time, if there was one, and better than the new best, if it's an edit
             if (rp.best > 0) best.$lte = rp.best;
@@ -914,7 +914,7 @@ export class ResultsService {
           };
 
           if (avgGotWorse) {
-            const average: any = { $gt: mode === 'edit' ? previousAvg : result.average };
+            const average: any = { $gt: 0 };
 
             // Make sure it's better than the record at the time, if there was one, and better than the new average, if it's an edit
             if (rp.average > 0) average.$lte = rp.average;

--- a/server/src/modules/results/tests/mocks/result.model.ts
+++ b/server/src/modules/results/tests/mocks/result.model.ts
@@ -30,6 +30,11 @@ export const ResultModelMock = (): any => ({
   find(query: any) {
     this.tempOutput = resultsStub();
 
+    if (query?._id) {
+      if (query._id.$ne)
+        this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el._id.toString() !== query._id.$ne);
+      else this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el._id.toString() === query._id.toString());
+    }
     if (query?.eventId) this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.eventId === query.eventId);
     if (query?.regionalSingleRecord) {
       this.tempOutput = this.tempOutput.filter(
@@ -51,6 +56,10 @@ export const ResultModelMock = (): any => ({
         );
       }
     }
+    if (query?.attempts) {
+      if (query.attempts.$size !== undefined)
+        this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.attempts.length === query.attempts.$size);
+    }
     if (query?.best) {
       if (query.best.$gt !== undefined)
         this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.best > query.best.$gt);
@@ -59,7 +68,11 @@ export const ResultModelMock = (): any => ({
       else this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.best === query.best);
     }
     if (query?.average) {
-      this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.average === query.average);
+      if (query.average.$gt !== undefined)
+        this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.average > query.average.$gt);
+      else if (query.average.$lte !== undefined)
+        this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.average <= query.average.$lte);
+      else this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.average === query.average);
     }
 
     return this;

--- a/server/src/modules/results/tests/mocks/result.model.ts
+++ b/server/src/modules/results/tests/mocks/result.model.ts
@@ -52,7 +52,11 @@ export const ResultModelMock = (): any => ({
       }
     }
     if (query?.best) {
-      this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.best === query.best);
+      if (query.best.$gt !== undefined)
+        this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.best > query.best.$gt);
+      else if (query.best.$lte !== undefined)
+        this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.best <= query.best.$lte);
+      else this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.best === query.best);
     }
     if (query?.average) {
       this.tempOutput = this.tempOutput.filter((el: ResultDocument) => el.average === query.average);

--- a/server/src/modules/results/tests/results.service.spec.ts
+++ b/server/src/modules/results/tests/results.service.spec.ts
@@ -263,14 +263,14 @@ describe('ResultsService', () => {
 
         expect(setEventSingleRecordsMock).toHaveBeenCalledWith(event, WcaRecordType.WR, {
           _id: { $ne: result._id },
-          best: { $gt: 2148, $lte: 3546 },
+          best: { $gt: 0, $lte: 3546 },
           date: { $gte: result.date },
           eventId: '333_team_bld',
         });
         expect(setEventAvgRecordsMock).toHaveBeenCalledWith(event, WcaRecordType.WR, {
           _id: { $ne: result._id },
           attempts: { $size: 5 },
-          average: { $gt: 3157, $lte: 4178 },
+          average: { $gt: 0, $lte: 4178 },
           date: { $gte: result.date },
           eventId: '333_team_bld',
         });
@@ -288,14 +288,14 @@ describe('ResultsService', () => {
 
         expect(setEventSingleRecordsMock).toHaveBeenCalledWith(event, WcaRecordType.WR, {
           _id: { $ne: result._id },
-          best: { $gt: 2148, $lte: 5059 },
+          best: { $gt: 0, $lte: 5059 },
           date: { $gte: result.date },
           eventId: '333_team_bld',
         });
         expect(setEventAvgRecordsMock).toHaveBeenCalledWith(event, WcaRecordType.WR, {
           _id: { $ne: result._id },
           attempts: { $size: 5 },
-          average: { $gt: 3157, $lte: 11740 },
+          average: { $gt: 0, $lte: 11740 },
           date: { $gte: result.date },
           eventId: '333_team_bld',
         });

--- a/server/src/modules/results/tests/results.service.spec.ts
+++ b/server/src/modules/results/tests/results.service.spec.ts
@@ -159,6 +159,40 @@ describe('ResultsService', () => {
         expect(createdResult.average).toBe(4053);
       });
 
+      it('throws an error when one of the competitors already has a result in the round', async () => {
+        const new333Result: CreateResultDto = {
+          eventId: '333',
+          competitionId: 'Munich19022023',
+          date: new Date('2023-02-19T00:00:00Z'),
+          unapproved: true,
+          personIds: [1],
+          ranking: 0,
+          attempts: [{ result: 1568 }, { result: 2054 }, { result: 1911 }, { result: 1723 }, { result: 1489 }],
+          best: null,
+          average: null,
+        };
+
+        await expect(resultsService.createResult(new333Result, '333-r1', { user: adminUser })).rejects.toThrowError(
+          new BadRequestException('That competitor already has a result in this round'),
+        );
+
+        const newTeamBldResult: CreateResultDto = {
+          eventId: '333_team_bld',
+          competitionId: 'Munich19022023',
+          date: new Date('2023-02-19T00:00:00Z'),
+          unapproved: true,
+          personIds: [99, 2],
+          ranking: 0,
+          attempts: [{ result: 4085 }, { result: 5942 }, { result: 3309 }, { result: 3820 }, { result: 4255 }],
+          best: null,
+          average: null,
+        };
+
+        await expect(
+          resultsService.createResult(newTeamBldResult, '333_team_bld-r1', { user: adminUser }),
+        ).rejects.toThrowError(new BadRequestException('One of the competitors already has a result in this round'));
+      });
+
       it('throws an error when the round is not found', async () => {
         await expect(
           resultsService.createResult(

--- a/server/src/modules/results/tests/results.service.spec.ts
+++ b/server/src/modules/results/tests/results.service.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
+import C from '@sh/constants';
 import { MyLogger } from '~/src/modules/my-logger/my-logger.service';
 import { EventsService } from '@m/events/events.service';
 import { ResultsService } from '@m/results/results.service';
@@ -20,14 +22,20 @@ import { RecordTypesServiceMock } from '@m/record-types/tests/mocks/record-types
 import { PersonsServiceMock } from '@m/persons/tests/mocks/persons.service';
 import { ResultModelMock } from '@m/results/tests/mocks/result.model';
 import { RoundModelMock } from '~/src/modules/contests/tests/mocks/round.model';
-import { CompetitionModelMock } from '~/src/modules/contests/tests/mocks/contest.model';
+import { ContestModelMock } from '~/src/modules/contests/tests/mocks/contest.model';
 import { AuthServiceMock } from '@m/auth/tests/mocks/auth.service';
 import { CreateResultDto } from '../dto/create-result.dto';
+import { SubmitResultDto } from '~/src/modules/results/dto/submit-result.dto';
 
-const mockUser: IPartialUser = {
+const adminUser: IPartialUser = {
   personId: 1,
-  username: 'testuser',
+  username: 'adminuser',
   roles: [Role.Admin],
+};
+const modUser: IPartialUser = {
+  personId: 2,
+  username: 'moduser',
+  roles: [Role.Moderator],
 };
 
 describe('ResultsService', () => {
@@ -75,7 +83,7 @@ describe('ResultsService', () => {
         },
         {
           provide: getModelToken('Competition'),
-          useFactory: CompetitionModelMock,
+          useFactory: ContestModelMock,
         },
         {
           provide: getModelToken('Schedule'),
@@ -105,7 +113,7 @@ describe('ResultsService', () => {
     });
 
     describe('createResult', () => {
-      it('creates new 3x3x3 result without error', async () => {
+      it('creates new 3x3x3 result', async () => {
         const newResult: CreateResultDto = {
           eventId: '333',
           competitionId: 'Munich19022023',
@@ -118,16 +126,115 @@ describe('ResultsService', () => {
           average: 1056,
         };
 
-        await resultsService.createResult(newResult, '333-r1', { user: mockUser });
-        const createdResult = newResult as unknown as ResultDocument;
+        await resultsService.createResult(newResult, '333-r1', { user: adminUser });
+        const createdResult = newResult as ResultDocument; // createResult directly edits newResult
 
         expect(createdResult.regionalSingleRecord).toBe('WR');
         expect(createdResult.regionalAverageRecord).toBe('WR');
       });
+
+      it('throws an error when the round is not found', async () => {
+        await expect(
+          resultsService.createResult(
+            { competitionId: 'Munich19022023', eventId: '333' } as CreateResultDto,
+            '333-INVALID_ROUND_NUMBER',
+            { user: adminUser },
+          ),
+        ).rejects.toThrowError(new BadRequestException('Round not found'));
+      });
+
+      it('throws an error when the number of competitors in the result is wrong', async () => {
+        await expect(
+          resultsService.createResult(
+            { competitionId: 'Munich19022023', eventId: '333', personIds: [1, 2, 3] } as CreateResultDto,
+            '333-r1',
+            { user: adminUser },
+          ),
+        ).rejects.toThrowError(new BadRequestException('This event must have 1 participant'));
+      });
+
+      it('throws an error when the number of non-empty attempts is 0', async () => {
+        await expect(
+          resultsService.createResult(
+            {
+              competitionId: 'Munich19022023',
+              eventId: '333',
+              personIds: [1],
+              attempts: [{ result: 0 }],
+            } as CreateResultDto,
+            '333-r1',
+            { user: adminUser },
+          ),
+        ).rejects.toThrowError(new BadRequestException('Please enter at least one attempt'));
+      });
     });
 
-    // describe('deleteContestResult', () => {});
+    describe('submitResult', () => {
+      it('submits new 4x4x4 Blindfolded result', async () => {
+        const newResult: SubmitResultDto = {
+          eventId: '444bf',
+          competitionId: 'Munich19022023',
+          date: new Date('2024-08-11T00:00:00Z'),
+          unapproved: true,
+          personIds: [99],
+          ranking: 0,
+          attempts: [{ result: 10085 }],
+          best: 10085,
+          average: 0,
+          videoLink: 'link.com',
+        };
 
-    // describe('submitResult', () => {});
+        const createdResult = await resultsService.submitResult(newResult, adminUser);
+
+        expect(createdResult.regionalSingleRecord).toBeUndefined();
+        expect(createdResult.regionalAverageRecord).toBeUndefined();
+      });
+
+      it('throws an error when there is no video link', async () => {
+        await expect(
+          resultsService.submitResult(
+            {
+              eventId: '444bf',
+              personIds: [1],
+              attempts: [{ result: 10000 }],
+              videoLink: undefined,
+            } as SubmitResultDto,
+            adminUser,
+          ),
+        ).rejects.toThrowError(new BadRequestException('Please enter a video link'));
+      });
+
+      it('throws an error when a non-admin submits a result with an empty video link', async () => {
+        await expect(
+          resultsService.submitResult(
+            {
+              eventId: '444bf',
+              personIds: [1],
+              attempts: [{ result: 10000 }],
+              videoLink: '',
+            } as SubmitResultDto,
+            modUser,
+          ),
+        ).rejects.toThrowError(new BadRequestException('Please enter a video link'));
+      });
+
+      it('throws an error when a non-admin submits a result with unknown time', async () => {
+        await expect(
+          resultsService.submitResult(
+            {
+              eventId: '444bf',
+              personIds: [1],
+              attempts: [{ result: C.maxTime }],
+              videoLink: 'link.com',
+            } as SubmitResultDto,
+            modUser,
+          ),
+        ).rejects.toThrowError(new BadRequestException('You are not authorized to set unknown time'));
+      });
+    });
+
+    // describe('editResult', () => {});
+
+    // describe('deleteResult', () => {});
   });
 });

--- a/server/src/modules/results/tests/stubs/results.stub.ts
+++ b/server/src/modules/results/tests/stubs/results.stub.ts
@@ -4,9 +4,9 @@ import { WcaRecordType } from '@sh/enums';
 
 export const resultsStub = (): ResultDocument[] => {
   return [
-    // Fake result
+    // Fake results
     {
-      _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c44'),
+      _id: new mongoose.Types.ObjectId('aaaaaaaaaaaaaaaaaaaaaaaa'),
       competitionId: 'FMTestComp2023',
       eventId: '333fm',
       date: new Date('2023-07-01T00:00:00Z'),
@@ -16,18 +16,29 @@ export const resultsStub = (): ResultDocument[] => {
       best: 39,
       average: 48,
     },
-    // Real results
     {
-      _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c44'),
-      competitionId: 'Munich19022023',
-      eventId: '333_team_bld',
-      date: new Date('2023-02-19T00:00:00Z'),
-      personIds: [2, 4],
-      ranking: 2,
-      attempts: [{ result: 14186 }, { result: 10247 }, { result: 10787 }, { result: 17962 }, { result: 5059 }],
-      best: 5059,
-      average: 11740,
+      _id: new mongoose.Types.ObjectId('bbbbbbbbbbbbbbbbbbbbbbbb'),
+      eventId: '444bf',
+      date: new Date('2023-06-27T00:00:00Z'),
+      personIds: [1],
+      attempts: [{ result: 9514 }],
+      best: 9514,
+      average: 0,
+      videoLink: 'link.com',
+      discussionLink: 'link.net',
     },
+    {
+      _id: new mongoose.Types.ObjectId('cccccccccccccccccccccccc'),
+      competitionId: 'Pretend Comp 2024',
+      eventId: '333_team_bld',
+      date: new Date('2024-08-11T00:00:00Z'),
+      personIds: [3, 1],
+      ranking: 1,
+      attempts: [{ result: 3391 }, { result: 4489 }, { result: 3542 }, { result: -1 }, { result: 3722 }],
+      best: 3391,
+      average: 3918,
+    },
+    // Real results
     {
       _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c45'),
       competitionId: 'Munich19022023',
@@ -236,17 +247,6 @@ export const resultsStub = (): ResultDocument[] => {
       attempts: [{ result: 9296 }, { result: -2 }, { result: -2 }, { result: -2 }, { result: -2 }],
       best: 9296,
       average: -1,
-    },
-    {
-      _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c43'),
-      competitionId: 'Munich19022023',
-      eventId: '333_team_bld',
-      date: new Date('2023-02-19T00:00:00Z'),
-      personIds: [3, 1],
-      ranking: 1,
-      attempts: [{ result: 2148 }, { result: 2866 }, { result: 3614 }, { result: -1 }, { result: 2990 }],
-      best: 2148,
-      average: 3157,
     },
     {
       _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c59'),
@@ -953,17 +953,6 @@ export const resultsStub = (): ResultDocument[] => {
       attempts: [{ result: 2832 }, { result: 3159 }, { result: 2769 }, { result: 3473 }, { result: 3076 }],
       best: 2769,
       average: 3022,
-    },
-    {
-      _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c7d'),
-      eventId: '444bf',
-      date: new Date('2023-06-27T00:00:00Z'),
-      personIds: [1],
-      attempts: [{ result: 9514 }],
-      best: 9514,
-      average: 0,
-      videoLink: 'link.com',
-      discussionLink: 'link.net',
     },
   ] as ResultDocument[];
 };

--- a/server/src/modules/results/tests/stubs/results.stub.ts
+++ b/server/src/modules/results/tests/stubs/results.stub.ts
@@ -954,5 +954,16 @@ export const resultsStub = (): ResultDocument[] => {
       best: 2769,
       average: 3022,
     },
+    {
+      _id: new mongoose.Types.ObjectId('649fe9c3ecadd98a79f99c7d'),
+      eventId: '444bf',
+      date: new Date('2023-06-27T00:00:00Z'),
+      personIds: [1],
+      attempts: [{ result: 9514 }],
+      best: 9514,
+      average: 0,
+      videoLink: 'link.com',
+      discussionLink: 'link.net',
+    },
   ] as ResultDocument[];
 };


### PR DESCRIPTION
1. Make the edit result feature work the same way as on WCA Live, directly editing the result instead of deleting it first.
2. Show confirmation dialog before deleting a result.
3. Scroll to the top of the data entry page when clicking edit on a result.
4. Allow external data entry using the competitor's WCA ID.
5. Improve result validation, and validate results on edit too.
6. Overhaul the code for setting or removing future records when a new record result is entered/edited. Also do this immediately, not just on contest publication. Also do this when editing a submitted result (this was only done on approval before).
7. Send email to the person who submitted a video-based result when their result gets approved.
8. Simplify some code in the ContestForm and fix a bug with the new event dropdown.
9. Reduce the amount of data fetched after every entered result.
10. Refactor a lot of code.
11. Add a bunch of new tests for the results service.