### PR TITLE
Update results validation and more

### DIFF
--- a/client/app/components/RoundResultsTable.tsx
+++ b/client/app/components/RoundResultsTable.tsx
@@ -2,7 +2,7 @@ import Time from '@c/Time';
 import Solves from '@c/Solves';
 import Competitor from '@c/Competitor';
 import Button from '@c/UI/Button';
-import { IResult, IRound, IPerson, IEvent, IRecordType } from '@sh/types';
+import { IResult, IRound, IPerson, IEvent, IRecordType, IAttempt } from '@sh/types';
 import { RoundFormat, RoundProceed, RoundType } from '@sh/enums';
 import { getRoundRanksWithAverage } from '@sh/sharedFunctions';
 import { roundFormats } from '@sh/roundFormats';
@@ -27,7 +27,8 @@ const RoundResultsTable = ({
   loadingId?: string;
   disableEditAndDelete?: boolean;
 }) => {
-  const roundCanHaveAverage = roundFormats.find((rf) => rf.value === round.format).attempts >= 3;
+  const roundFormat = roundFormats.find((rf) => rf.value === round.format);
+  const roundCanHaveAverage = roundFormat.attempts >= 3;
   const roundRanksWithAverage = getRoundRanksWithAverage(round.format);
   let lastRanking = 0;
 
@@ -51,6 +52,11 @@ const RoundResultsTable = ({
 
     return {};
   };
+
+  const getAttemptsIncludingEmptyAtTheEnd = (attempts: IAttempt[]): IAttempt[] => [
+    ...attempts,
+    ...Array(roundFormat.attempts - attempts.length).fill({ result: 0 }),
+  ];
 
   return (
     <div className="flex-grow-1 table-responsive">
@@ -96,7 +102,7 @@ const RoundResultsTable = ({
                   </td>
                 )}
                 <td>
-                  <Solves event={event} attempts={result.attempts} />
+                  <Solves event={event} attempts={getAttemptsIncludingEmptyAtTheEnd(result.attempts)} />
                 </td>
                 {onEditResult && (
                   <td className="py-1">

--- a/client/app/components/RoundResultsTable.tsx
+++ b/client/app/components/RoundResultsTable.tsx
@@ -2,7 +2,7 @@ import Time from '@c/Time';
 import Solves from '@c/Solves';
 import Competitor from '@c/Competitor';
 import Button from '@c/UI/Button';
-import { IResult, IRound, IPerson, IEvent, IRecordType, IAttempt } from '@sh/types';
+import { IResult, IRound, IPerson, IEvent, IRecordType } from '@sh/types';
 import { RoundFormat, RoundProceed, RoundType } from '@sh/enums';
 import { getRoundRanksWithAverage } from '@sh/sharedFunctions';
 import { roundFormats } from '@sh/roundFormats';
@@ -53,11 +53,6 @@ const RoundResultsTable = ({
     return {};
   };
 
-  const getAttemptsIncludingEmptyAtTheEnd = (attempts: IAttempt[]): IAttempt[] => [
-    ...attempts,
-    ...Array(roundFormat.attempts - attempts.length).fill({ result: 0 }),
-  ];
-
   return (
     <div className="flex-grow-1 table-responsive">
       <table className="table table-hover table-responsive text-nowrap">
@@ -102,7 +97,7 @@ const RoundResultsTable = ({
                   </td>
                 )}
                 <td>
-                  <Solves event={event} attempts={getAttemptsIncludingEmptyAtTheEnd(result.attempts)} />
+                  <Solves event={event} attempts={result.attempts} />
                 </td>
                 {onEditResult && (
                   <td className="py-1">

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -7,6 +7,12 @@ const Home = () => {
   return (
     <div className="px-3">
       <h1 className="mb-4 text-center">Cubing Contests</h1>
+
+      <div className="alert alert-warning mb-4">
+        We're looking for Typescript deveopers to aid us in the development of Cubing Contests. Please reach out to this
+        email address if you're interested: {C.contactEmail}.
+      </div>
+
       <p>
         This is a place for hosting unofficial Rubik's cube competitions, unofficial events held at{' '}
         <a href="https://worldcubeassociation.org/" target="_blank">

--- a/server/src/app-dto/enter-attempt.dto.ts
+++ b/server/src/app-dto/enter-attempt.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, Matches, Min } from 'class-validator';
+import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, Matches, Min, NotEquals } from 'class-validator';
 import C from '@sh/constants';
 
 export class EnterAttemptDto {
@@ -28,5 +28,6 @@ export class EnterAttemptDto {
   attemptNumber: number;
 
   @IsInt()
+  @NotEquals(0)
   attemptResult: number;
 }

--- a/server/src/app-dto/enter-results.dto.ts
+++ b/server/src/app-dto/enter-results.dto.ts
@@ -11,7 +11,7 @@ import {
   Validate,
   ValidateNested,
 } from 'class-validator';
-import { AttemptDto, HasNonDnsResult } from '../modules/results/dto/create-result.dto';
+import { AttemptDto, NotAllDnsAndNotAllEmpty } from '../modules/results/dto/create-result.dto';
 import { Type } from 'class-transformer';
 import { IAttempt } from '@sh/types';
 import C from '@sh/constants';
@@ -29,6 +29,7 @@ export class EnterResultsDto {
   roundNumber: number;
 
   @ValidateNested({ each: true })
+  @Type(() => ExternalResultDto)
   results: ExternalResultDto[];
 }
 
@@ -45,7 +46,7 @@ export class ExternalResultDto {
 
   @ArrayMinSize(1)
   @ArrayMaxSize(5)
-  @Validate(HasNonDnsResult)
+  @Validate(NotAllDnsAndNotAllEmpty)
   @ValidateNested({ each: true })
   @Type(() => AttemptDto)
   attempts: IAttempt[];

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -150,6 +150,7 @@ export class AppService {
       );
     }
   }
+
   async enterResultsFromExternalDevice(enterResultsDto: EnterResultsDto) {
     const round = await this.contestsService.getContestRound(
       enterResultsDto.competitionWcaId,

--- a/server/src/helpers/customValidators.ts
+++ b/server/src/helpers/customValidators.ts
@@ -1,0 +1,24 @@
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+import { IAttempt } from '@sh/types';
+
+@ValidatorConstraint({ name: 'VideoBasedAttempt', async: false })
+export class VideoBasedAttempt implements ValidatorConstraintInterface {
+  validate(attempts: IAttempt[]) {
+    return attempts.some((a) => a.result > 0) && !attempts.some((a) => a.result === 0);
+  }
+
+  defaultMessage() {
+    return 'You cannot submit only DNF/DNS attempts, and you cannot submit empty attempts';
+  }
+}
+
+@ValidatorConstraint({ name: 'NotAllDnsAndNotAllEmpty', async: false })
+export class NotAllDnsAndNotAllEmpty implements ValidatorConstraintInterface {
+  validate(attempts: IAttempt[]) {
+    return attempts.some((a) => a.result !== -2) && attempts.some((a) => a.result !== 0);
+  }
+
+  defaultMessage() {
+    return 'You cannot submit only DNS attempts or only empty attempts';
+  }
+}

--- a/server/src/modules/contests/contests.service.ts
+++ b/server/src/modules/contests/contests.service.ts
@@ -377,10 +377,17 @@ export class ContestsService {
           { subject: `Contest approved: ${contest.shortName}` },
         );
       } else if (newState === ContestState.Finished) {
-        const incompleteResult = await this.resultModel.findOne({ 'attempts.result': 0 }).exec();
-
+        const incompleteResult = await this.resultModel.findOne({ competitionId, 'attempts.result': 0 }).exec();
         if (incompleteResult)
           throw new BadRequestException(`This contest has an unentered attempt in event ${incompleteResult.eventId}`);
+
+        const dnsOnlyResult = await this.resultModel
+          .findOne({ competitionId, attempts: { $not: { $elemMatch: { result: { $ne: -2 } } } } })
+          .exec();
+        if (dnsOnlyResult)
+          throw new BadRequestException(
+            `This contest has a result with only DNS attempts in event ${dnsOnlyResult.eventId}`,
+          );
 
         contest.queuePosition = undefined;
 
@@ -397,7 +404,7 @@ export class ContestsService {
     if (isAdmin && newState === ContestState.Published) {
       this.logger.log(`Publishing contest ${contest.competitionId}...`);
 
-      if (contest.participants < C.minCompetitorsForUnofficialCompsAndMeetups) {
+      if (contest.type !== ContestType.WcaComp && contest.participants < C.minCompetitorsForUnofficialCompsAndMeetups) {
         throw new BadRequestException(
           `A meetup or unofficial competition may not have fewer than ${C.minCompetitorsForUnofficialCompsAndMeetups} competitors`,
         );

--- a/server/src/modules/results/dto/create-result.dto.ts
+++ b/server/src/modules/results/dto/create-result.dto.ts
@@ -10,26 +10,13 @@ import {
   Min,
   ValidateNested,
   Max,
-  ValidatorConstraint,
-  ValidatorConstraintInterface,
   Validate,
 } from 'class-validator';
 import { IAttempt, IResult } from '@sh/types';
 import { Type } from 'class-transformer';
 import C from '@sh/constants';
 import { DATE_VALIDATION_MSG } from '~/src/helpers/messages';
-
-// This is almost the same as HasNonDnfDnsResult in SubmitResultDto
-@ValidatorConstraint({ name: 'HasNonDnsResult', async: false })
-export class HasNonDnsResult implements ValidatorConstraintInterface {
-  validate(attempts: IAttempt[]) {
-    return attempts.some((a) => a.result !== -2);
-  }
-
-  defaultMessage() {
-    return 'You cannot submit only DNS results';
-  }
-}
+import { NotAllDnsAndNotAllEmpty } from '~/src/helpers/customValidators';
 
 export class CreateResultDto implements IResult {
   @IsOptional()
@@ -58,7 +45,7 @@ export class CreateResultDto implements IResult {
 
   @ArrayMinSize(1)
   @ArrayMaxSize(5)
-  @Validate(HasNonDnsResult)
+  @Validate(NotAllDnsAndNotAllEmpty)
   @ValidateNested({ each: true })
   @Type(() => AttemptDto)
   attempts: IAttempt[];
@@ -80,3 +67,4 @@ export class AttemptDto implements IAttempt {
   @Max(C.maxTime - 1)
   memo?: number;
 }
+export { NotAllDnsAndNotAllEmpty };

--- a/server/src/modules/results/dto/submit-result.dto.ts
+++ b/server/src/modules/results/dto/submit-result.dto.ts
@@ -1,28 +1,9 @@
 import { Type } from 'class-transformer';
 import { AttemptDto, CreateResultDto } from './create-result.dto';
-import {
-  ArrayMaxSize,
-  ArrayMinSize,
-  IsOptional,
-  IsUrl,
-  Validate,
-  ValidateNested,
-  ValidatorConstraint,
-  ValidatorConstraintInterface,
-} from 'class-validator';
+import { ArrayMaxSize, ArrayMinSize, IsOptional, IsUrl, Validate, ValidateNested } from 'class-validator';
 import { IAttempt, IResult } from '@sh/types';
 import { DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from '~/src/helpers/messages';
-
-@ValidatorConstraint({ name: 'HasNonDnfDnsResult', async: false })
-class VideoBasedAttempt implements ValidatorConstraintInterface {
-  validate(attempts: IAttempt[]) {
-    return attempts.some((a) => a.result > 0) && !attempts.some((a) => a.result === 0);
-  }
-
-  defaultMessage() {
-    return 'You cannot submit only DNF/DNS results, and you cannot submit empty attempts';
-  }
-}
+import { VideoBasedAttempt } from '~/src/helpers/customValidators';
 
 export class SubmitResultDto extends CreateResultDto implements IResult {
   @ArrayMinSize(1)

--- a/server/src/modules/results/dto/update-result.dto.ts
+++ b/server/src/modules/results/dto/update-result.dto.ts
@@ -11,7 +11,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from '~/src/helpers/messages';
-import { AttemptDto, HasNonDnsResult } from './create-result.dto';
+import { AttemptDto, NotAllDnsAndNotAllEmpty } from './create-result.dto';
 import { IAttempt, IUpdateResultDto } from '@sh/types';
 
 export class UpdateResultDto implements IUpdateResultDto {
@@ -28,7 +28,7 @@ export class UpdateResultDto implements IUpdateResultDto {
 
   @ArrayMinSize(1)
   @ArrayMaxSize(5)
-  @Validate(HasNonDnsResult)
+  @Validate(NotAllDnsAndNotAllEmpty)
   @ValidateNested({ each: true })
   @Type(() => AttemptDto)
   attempts: IAttempt[];

--- a/server/src/modules/results/tests/results.service.spec.ts
+++ b/server/src/modules/results/tests/results.service.spec.ts
@@ -212,21 +212,6 @@ describe('ResultsService', () => {
           ),
         ).rejects.toThrowError(new BadRequestException('This event must have 1 participant'));
       });
-
-      it('throws an error when the number of non-empty attempts is 0', async () => {
-        await expect(
-          resultsService.createResult(
-            {
-              competitionId: 'Munich19022023',
-              eventId: '333',
-              personIds: [1],
-              attempts: [{ result: 0 }],
-            } as CreateResultDto,
-            '333-r1',
-            { user: adminUser },
-          ),
-        ).rejects.toThrowError(new BadRequestException('Please enter at least one attempt'));
-      });
     });
 
     describe('submitResult', () => {


### PR DESCRIPTION
- Update results validation
- Disallow empty results when submitting individual attempts with external devices
- Disallow finishing contest if there is a result with only DNS attempts
- No longer remove empty attempts from the end of an attempts array
- Add banner about looking for developers to the home  page
- Update inconsistency checks
- Fix bugs