### PR TITLE
Automatically replace attempt with DNF if above time limit

### DIFF
--- a/client/app/components/AttemptInput.tsx
+++ b/client/app/components/AttemptInput.tsx
@@ -223,6 +223,9 @@ const AttemptInput = ({
           newText.length <= C.maxFmMoves.toString().length ||
           (newText.length <= 8 && event.format !== EventFormat.Number)
         ) {
+          if (timeLimit && +newText > timeLimit.centiseconds) {
+            return dnfTheAttempt();
+          }
           const newAttempt = getAttempt(attempt, event, forMemo ? attemptText : newText, {
             solved,
             attempted,

--- a/client/app/components/adminAndModerator/ResultForm.tsx
+++ b/client/app/components/adminAndModerator/ResultForm.tsx
@@ -12,7 +12,7 @@ import EventButtons from '@c/EventButtons';
 import { IAttempt, IContestEvent, IEvent, IPerson, IRecordPair, IRecordType, IResult, IRound } from '@sh/types';
 import { EventFormat, RoundFormat, RoundType } from '@sh/enums';
 import { roundFormats } from '@sh/roundFormats';
-import { getMakesCutoff, getBestAndAverage, setResultRecords } from '@sh/sharedFunctions';
+import { getMakesCutoff, getBestAndAverage, setResultRecords, getFormattedTime } from '@sh/sharedFunctions';
 import { roundTypes } from '~/helpers/roundTypes';
 import { roundFormatOptions } from '~/helpers/multipleChoiceOptions';
 import { MainContext } from '~/helpers/contexts';
@@ -296,6 +296,20 @@ const ResultForm = ({
             )}
           </div>
         )}
+        <div className="mt-2">
+          {round?.timeLimit && (
+            <div>
+            Time limit:&nbsp;
+              {getFormattedTime(round.timeLimit.centiseconds)} {round?.timeLimit.cumulativeRoundIds.length > 0 && 'in total'}
+            </div>
+          )}
+          {round?.cutoff && (
+            <div>
+              Cutoff:&nbsp;
+              {getFormattedTime(round.cutoff.attemptResult)}
+            </div>
+          )}
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
Does not affect submit-video page - after the changes attempt is replaced only if `timeLimit` exists.

[Screencast From 2024-10-12 21-47-04.webm](https://github.com/user-attachments/assets/3f0ac9a1-dd7b-41cb-9cb1-9cc419884932)
