### PR TITLE
Add the round proceeding feature

### DIFF
--- a/client/app/components/RoundResultsTable.tsx
+++ b/client/app/components/RoundResultsTable.tsx
@@ -34,14 +34,6 @@ const RoundResultsTable = ({
   const roundFormat = roundFormats.find((rf) => rf.value === round.format) as IRoundFormat;
   const roundCanHaveAverage = roundFormat.attempts >= 3;
   let lastRanking = 0;
-  //     // This is necessary to account for rounding down to 0 (see Math.floor() below)
-  //     (result.ranking === 1 ||
-  //       // Final round and the ranking is in the top 3
-  //       // Non-final round and the ranking satisfies the proceed parameters
-  //       (round.proceed && result.ranking <=
-  //           (round.proceed.type === RoundProceed.Number
-  //             ? round.proceed.value
-  //             : Math.floor((round.results.length * round.proceed.value) / 100))))
 
   // Gets green highlight styling if the result is not DNF/DNS and made podium or is good enough to proceed to the next round
   const getRankingHighlight = (result: IResult) => {

--- a/client/app/components/Time.tsx
+++ b/client/app/components/Time.tsx
@@ -1,9 +1,9 @@
-import { IEvent, IRecordType, IResult, type ISubmittedResult } from "~/shared_helpers/types.ts";
+import { IEvent, IRecordType, IResult, type IVideoBasedResult } from "~/shared_helpers/types.ts";
 import { getBSClassFromColor } from "~/helpers/utilityFunctions.ts";
 import { getFormattedTime } from "~/shared_helpers/sharedFunctions.ts";
 
 type Props = {
-  result: IResult | ISubmittedResult;
+  result: IResult | IVideoBasedResult;
   event: IEvent;
   recordTypes: IRecordType[];
   average?: boolean;

--- a/client/app/components/adminAndModerator/DataEntryScreen.tsx
+++ b/client/app/components/adminAndModerator/DataEntryScreen.tsx
@@ -77,9 +77,9 @@ const DataEntryScreen = ({
   );
 
   const roundNumber = currContestEvent.rounds.findIndex((r) => (r as any)._id === round._id) + 1;
-  const isEditable = roundNumber === 1 || resultUnderEdit;
+  const isEditable = round.open;
   const maxAllowedRounds = getMaxAllowedRounds(currContestEvent.rounds);
-  const isOpenableRound = roundNumber > 1 && round.results.length === 0 && maxAllowedRounds >= roundNumber;
+  const isOpenableRound = !round.open && maxAllowedRounds >= roundNumber;
   const lastActiveAttempt = getMakesCutoff(attempts, round?.cutoff)
     ? attempts.length
     : (round.cutoff as ICutoff).numberOfAttempts;
@@ -389,21 +389,30 @@ const DataEntryScreen = ({
         <div className="col-lg-9">
           <h3 className="mt-2 mb-4 text-center">{contest.shortName} &ndash; {shortenEventName(currEvent.name)}</h3>
 
-          {isEditable
+          {round.open || round.results.length > 0
             ? (
               <RoundResultsTable
                 round={round}
                 event={currEvent}
                 persons={persons}
                 recordTypes={activeRecordTypes}
-                onEditResult={editResult}
-                onDeleteResult={deleteResult}
+                onEditResult={round.open ? editResult : undefined}
+                onDeleteResult={round.open ? deleteResult : undefined}
                 disableEditAndDelete={resultUnderEdit !== null}
                 loadingId={loadingId}
               />
             )
             : isOpenableRound
-            ? <Button onClick={openRound} className="d-block mx-auto">Open Round</Button>
+            ? (
+              <div>
+                <Button onClick={openRound} className="d-block mt-5 mx-auto">Open Round</Button>
+                <p className="mt-4 text-center text-danger fst-italic">
+                  Do NOT begin this round before opening it using the button, which checks that the round may be opened.
+                  Also, please mind that manually adding/removing competitors to/from a subsequent round hasn't been
+                  implemented yet.
+                </p>
+              </div>
+            )
             : <p className="text-center fst-italic">This round cannot be opened yet</p>}
         </div>
       </div>

--- a/client/app/components/adminAndModerator/DataEntryScreen.tsx
+++ b/client/app/components/adminAndModerator/DataEntryScreen.tsx
@@ -230,7 +230,15 @@ const DataEntryScreen = ({
     if (!errors) setQueuePosition(payload);
   };
 
-  const openRound = () => {
+  const openRound = async () => {
+    const { payload, errors } = await myFetch.post(
+      `/competitions/${contest.competitionId}/open-round/${round.roundId}`,
+      {},
+    );
+
+    if (!errors) {
+      console.log("yay!", payload);
+    }
   };
 
   const submitMockResult = async () => {

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -33,7 +33,7 @@ import FormSelect from "~/app/components/form/FormSelect.tsx";
 import FormPersonInputs from "~/app/components/form/FormPersonInputs.tsx";
 import AttemptInput from "~/app/components/AttemptInput.tsx";
 import BestAndAverage from "~/app/components/adminAndModerator/BestAndAverage.tsx";
-import type { IRecordPair, ISubmittedResultDto } from "~/shared_helpers/interfaces/Result.ts";
+import type { IRecordPair, IVideoBasedResultDto } from "~/shared_helpers/interfaces/Result.ts";
 
 const userInfo: UserInfo = getUserInfo();
 const allowedRoundFormats: IRoundFormat[] = roundFormats.filter((rf) => rf.value !== RoundFormat.BestOf3);
@@ -141,7 +141,7 @@ const ResultsSubmissionForm = ({ resultId }: Props) => {
       return;
     }
 
-    const newResult: ISubmittedResultDto = {
+    const newResult: IVideoBasedResultDto = {
       eventId: event.eventId,
       date: date as Date,
       personIds: competitors.map((p: InputPerson) => (p as IPerson).personId),
@@ -174,7 +174,7 @@ const ResultsSubmissionForm = ({ resultId }: Props) => {
       };
       if (!approve) updateResultDto.unapproved = (submissionInfo as IAdminResultsSubmissionInfo).result.unapproved;
 
-      const { errors } = await myFetch.patch(`/results/${resultId}`, updateResultDto, {
+      const { errors } = await myFetch.patch(`/results/video-based/${resultId}`, updateResultDto, {
         loadingId,
         keepLoadingOnSuccess: true,
       });

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -13,6 +13,7 @@ import Button from "~/app/components/UI/Button.tsx";
 import CreatorDetails from "~/app/components/CreatorDetails.tsx";
 import {
   type IAdminResultsSubmissionInfo,
+  type ICreateVideoBasedResultDto,
   type IEvent,
   type IEventRecordPairs,
   type IFeAttempt,
@@ -21,7 +22,6 @@ import {
   type IResultsSubmissionInfo,
   type IRoundFormat,
   type IUpdateVideoBasedResultDto,
-  type IVideoBasedResultDto,
 } from "~/shared_helpers/types.ts";
 import { EventFormat, RoundFormat } from "~/shared_helpers/enums.ts";
 import { roundFormats } from "~/shared_helpers/roundFormats.ts";
@@ -142,7 +142,7 @@ const ResultsSubmissionForm = ({ resultId }: Props) => {
       return;
     }
 
-    const newResult: IVideoBasedResultDto = {
+    const newResult: ICreateVideoBasedResultDto = {
       eventId: event.eventId,
       date: date as Date,
       personIds: competitors.map((p: InputPerson) => (p as IPerson).personId),

--- a/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
+++ b/client/app/components/adminAndModerator/ResultsSubmissionForm.tsx
@@ -17,9 +17,11 @@ import {
   type IEventRecordPairs,
   type IFeAttempt,
   type IPerson,
+  type IRecordPair,
   type IResultsSubmissionInfo,
   type IRoundFormat,
-  type IUpdateResultDto,
+  type IUpdateVideoBasedResultDto,
+  type IVideoBasedResultDto,
 } from "~/shared_helpers/types.ts";
 import { EventFormat, RoundFormat } from "~/shared_helpers/enums.ts";
 import { roundFormats } from "~/shared_helpers/roundFormats.ts";
@@ -33,7 +35,6 @@ import FormSelect from "~/app/components/form/FormSelect.tsx";
 import FormPersonInputs from "~/app/components/form/FormPersonInputs.tsx";
 import AttemptInput from "~/app/components/AttemptInput.tsx";
 import BestAndAverage from "~/app/components/adminAndModerator/BestAndAverage.tsx";
-import type { IRecordPair, IVideoBasedResultDto } from "~/shared_helpers/interfaces/Result.ts";
 
 const userInfo: UserInfo = getUserInfo();
 const allowedRoundFormats: IRoundFormat[] = roundFormats.filter((rf) => rf.value !== RoundFormat.BestOf3);
@@ -165,7 +166,7 @@ const ResultsSubmissionForm = ({ resultId }: Props) => {
         if (!keepCompetitors) document.getElementById("Competitor_1")?.focus();
       }
     } else {
-      const updateResultDto: IUpdateResultDto = {
+      const updateResultDto: IUpdateVideoBasedResultDto = {
         date: newResult.date,
         personIds: newResult.personIds,
         attempts: newResult.attempts,

--- a/client/app/mod/page.tsx
+++ b/client/app/mod/page.tsx
@@ -218,7 +218,8 @@ const ModeratorDashboardPage = () => {
                                   <FontAwesomeIcon icon={faPencil} />
                                 </Link>
                               )}
-                              {(contest.state < ContestState.Finished || userInfo?.isAdmin) && (
+                              {(contest.state < ContestState.Published &&
+                                (contest.state < ContestState.Finished || userInfo?.isAdmin)) && (
                                 <Link
                                   href={`/mod/competition/${contest.competitionId}`}
                                   prefetch={false}

--- a/client/helpers/customHooks.ts
+++ b/client/helpers/customHooks.ts
@@ -31,7 +31,7 @@ export const useMyFetch = () => {
         authorize = false,
         redirect,
         fileName,
-        loadingId, // set loadingId to null to prevent automatic loading behavior
+        loadingId, // set loadingId to null to prevent automatic loading and error handling behavior
         keepLoadingOnSuccess = false,
       }: FetchOptions & {
         redirect?: string; // this can only be set if authorize is set too

--- a/client/shared_helpers/constants.ts
+++ b/client/shared_helpers/constants.ts
@@ -7,7 +7,10 @@ const C = {
   // Timeouts before revalidating a request in seconds
   rankingsRev: 120, //  2 minutes
   contestsRev: 60, // 1 minute
-  maxRounds: 10, // maximum number of rounds allowed
+  maxRounds: 4,
+  minResultsForThreeMoreRounds: 100,
+  minResultsForTwoMoreRounds: 16,
+  minResultsForOneMoreRound: 8,
   maxTime: 24 * 60 * 60 * 100, // 24 hours (IF THIS IS EVER UPDATED, ALSO CONSIDER THE LINES WITH 24000000 IN AttemptInput)
   maxFmMoves: 999,
   maxTimeLimit: 60 * 60 * 100, // 1 hour

--- a/client/shared_helpers/constants.ts
+++ b/client/shared_helpers/constants.ts
@@ -17,7 +17,7 @@ const C = {
   minCompetitorLimit: 5,
   minCompetitorsForNonWca: 3,
   maxConfirmationCodeAttempts: 3,
-  minProceedNumber: 3,
+  minProceedNumber: 2,
   maxProceedPercentage: 75,
   maxMeetupRounds: 15,
   confirmationCodeCooldown: 5 * 60 * 1000, // in milliseconds (5 minutes)

--- a/client/shared_helpers/interfaces/Result.ts
+++ b/client/shared_helpers/interfaces/Result.ts
@@ -43,7 +43,7 @@ export type IVideoBasedResult = Omit<IResult, "competitionId" | "ranking"> & {
   createdBy?: unknown; // user ID of the user who created the result
 };
 
-export interface IResultDto {
+export interface ICreateResultDto {
   eventId: string;
   personIds: number[];
   attempts: IFeAttempt[];
@@ -54,7 +54,7 @@ export interface IUpdateResultDto {
   attempts: IFeAttempt[];
 }
 
-export interface IVideoBasedResultDto extends IResultDto {
+export interface ICreateVideoBasedResultDto extends ICreateResultDto {
   date: Date;
   videoLink: string;
   discussionLink?: string;

--- a/client/shared_helpers/interfaces/Result.ts
+++ b/client/shared_helpers/interfaces/Result.ts
@@ -34,6 +34,7 @@ export interface IResult {
   average: number; // for FMC it's 100 times the mean (to avoid decimals)
   regionalSingleRecord?: string;
   regionalAverageRecord?: string;
+  proceeds?: true;
 }
 
 export type IVideoBasedResult = Omit<IResult, "competitionId" | "ranking"> & {

--- a/client/shared_helpers/interfaces/Result.ts
+++ b/client/shared_helpers/interfaces/Result.ts
@@ -36,7 +36,7 @@ export interface IResult {
   regionalAverageRecord?: string;
 }
 
-export type ISubmittedResult = Omit<IResult, "competitionId" | "ranking"> & {
+export type IVideoBasedResult = Omit<IResult, "competitionId" | "ranking"> & {
   videoLink: string;
   discussionLink?: string;
   createdBy?: unknown; // user ID of the user who created the result
@@ -48,19 +48,22 @@ export interface IResultDto {
   attempts: IFeAttempt[];
 }
 
-export interface ISubmittedResultDto extends IResultDto {
+export interface IUpdateResultDto {
+  personIds: number[];
+  attempts: IFeAttempt[];
+}
+
+export interface IVideoBasedResultDto extends IResultDto {
   date: Date;
   videoLink: string;
   discussionLink?: string;
 }
 
-export interface IUpdateResultDto {
-  date?: Date; // only used for submitted results
-  unapproved?: true; // only needed for updating submitted results, because they can be approved at the same time
-  personIds: number[];
-  attempts: IFeAttempt[];
-  videoLink?: string; // required for submitted results
-  discussionLink?: string; // only used for submitted results
+export interface IUpdateVideoBasedResultDto extends IUpdateResultDto {
+  date: Date;
+  unapproved?: true;
+  videoLink: string;
+  discussionLink?: string;
 }
 
 export interface IFeResult extends IResult {
@@ -109,7 +112,7 @@ export interface IResultsSubmissionInfo {
 
 // These are only used for the edit result page, so this information is admin-only
 export interface IAdminResultsSubmissionInfo extends IResultsSubmissionInfo {
-  result: ISubmittedResult;
+  result: IVideoBasedResult;
   persons: IPerson[];
   creator: IFeUser;
 }

--- a/client/shared_helpers/interfaces/Round.ts
+++ b/client/shared_helpers/interfaces/Round.ts
@@ -28,6 +28,7 @@ export interface IRound {
   // This is only set if it's not the final round
   proceed?: IProceed;
   results: IResult[]; // this is an empty array until results are posted
+  open?: true; // this is only set in ongoing contests for the last open round
 }
 
 export interface IRoundFormat {

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -11,7 +11,7 @@ import {
   type IRecordPair,
   type IResult,
   type IRoundFormat,
-  type ISubmittedResult,
+  type IVideoBasedResult,
 } from "./types.ts";
 import { roundFormats } from "./roundFormats.ts";
 
@@ -49,11 +49,11 @@ export const compareAvgs = (a: AvgCompareObj, b: AvgCompareObj): number => {
 // IMPORTANT: it is assumed that recordPairs is sorted by importance (i.e. first WR, then the CRs, then NR, then PR)
 // and includes unapproved results
 export const setResultRecords = (
-  result: IResult | ISubmittedResult,
+  result: IResult | IVideoBasedResult,
   event: IEvent,
   recordPairs: IRecordPair[],
   noConsoleLog = false,
-): IResult | ISubmittedResult => {
+): IResult | IVideoBasedResult => {
   for (const recordPair of recordPairs) {
     // TO-DO: REMOVE HARD CODING TO WR!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     if (recordPair.wcaEquivalent === WcaRecordType.WR) {

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -232,8 +232,8 @@ export const getBestAndAverage = (
   return { best, average };
 };
 
-export const getRoundRanksWithAverage = (roundFormat: RoundFormat): boolean =>
-  [RoundFormat.Average, RoundFormat.Mean].includes(roundFormat);
+export const getIsProceedableResult = (result: IResult, roundFormat: IRoundFormat): boolean =>
+  (roundFormat.attempts >= 3 && result.average > 0) || result.best > 0;
 
 export const getDefaultAverageAttempts = (event: IEvent) => {
   const roundFormat = roundFormats.find((rf) => rf.value === event.defaultRoundFormat) as IRoundFormat;

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -233,7 +233,7 @@ export const getBestAndAverage = (
 };
 
 export const getIsProceedableResult = (result: IResult, roundFormat: IRoundFormat): boolean =>
-  (roundFormat.attempts >= 3 && result.average > 0) || result.best > 0;
+  (roundFormat.isAverage && result.average > 0) || result.best > 0;
 
 export const getDefaultAverageAttempts = (event: IEvent) => {
   const roundFormat = roundFormats.find((rf) => rf.value === event.defaultRoundFormat) as IRoundFormat;

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -292,14 +292,30 @@ export const getTotalRounds = (contestEvents: IContestEvent[]): number =>
 export const getSimplifiedString = (input: string): string => removeAccents(input.trim().toLocaleLowerCase());
 
 export const getMaxAllowedRounds = (rounds: IRound[]): number => {
-  if (rounds.length === 1 || rounds[0].results.length < C.minResultsForOneMoreRound) return 1;
+  const getRoundHasEnoughResults = (roundIndex: number) =>
+    rounds[roundIndex].results.length >= C.minResultsForOneMoreRound &&
+    rounds[roundIndex].results.filter((r) => r.proceeds).length >= C.minProceedNumber;
+
+  if (!getRoundHasEnoughResults(0)) return 1;
+
+  if (rounds[0].results.length < C.minResultsForTwoMoreRounds || !getRoundHasEnoughResults(1)) return 2;
+
   if (
-    rounds.length === 2 || rounds[0].results.length < C.minResultsForTwoMoreRounds ||
-    rounds[1].results.length < C.minResultsForOneMoreRound
-  ) return 2;
-  if (
-    rounds.length === 3 || rounds[0].results.length < C.minResultsForThreeMoreRounds ||
-    rounds[1].results.length < C.minResultsForTwoMoreRounds || rounds[2].results.length < C.minResultsForOneMoreRound
+    rounds[0].results.length < C.minResultsForThreeMoreRounds ||
+    rounds[1].results.length < C.minResultsForTwoMoreRounds || !getRoundHasEnoughResults(2)
   ) return 3;
+
   return 4;
+};
+
+export const parseRoundId = (roundId: string): [string, number] => {
+  const [eventPart, roundPart] = roundId.split("-");
+  if (!eventPart || !roundPart) throw new Error(`Invalid round ID: ${roundId}`);
+
+  const roundNumber = parseInt(roundPart.slice(1));
+  if (isNaN(roundNumber) || roundNumber < 1 || roundNumber > C.maxRounds) {
+    throw new Error(`Round ID has invalid round number: ${roundId}`);
+  }
+
+  return [eventPart, roundNumber];
 };

--- a/client/shared_helpers/sharedFunctions.ts
+++ b/client/shared_helpers/sharedFunctions.ts
@@ -10,6 +10,7 @@ import {
   type IPersonDto,
   type IRecordPair,
   type IResult,
+  IRound,
   type IRoundFormat,
   type IVideoBasedResult,
 } from "./types.ts";
@@ -289,3 +290,16 @@ export const getTotalRounds = (contestEvents: IContestEvent[]): number =>
   contestEvents.map((ce) => ce.rounds.length).reduce((prev, curr) => prev + curr, 0);
 
 export const getSimplifiedString = (input: string): string => removeAccents(input.trim().toLocaleLowerCase());
+
+export const getMaxAllowedRounds = (rounds: IRound[]): number => {
+  if (rounds.length === 1 || rounds[0].results.length < C.minResultsForOneMoreRound) return 1;
+  if (
+    rounds.length === 2 || rounds[0].results.length < C.minResultsForTwoMoreRounds ||
+    rounds[1].results.length < C.minResultsForOneMoreRound
+  ) return 2;
+  if (
+    rounds.length === 3 || rounds[0].results.length < C.minResultsForThreeMoreRounds ||
+    rounds[1].results.length < C.minResultsForTwoMoreRounds || rounds[2].results.length < C.minResultsForOneMoreRound
+  ) return 3;
+  return 4;
+};

--- a/client/shared_helpers/types.ts
+++ b/client/shared_helpers/types.ts
@@ -13,6 +13,7 @@ export type { IRecordType } from "./interfaces/RecordType.ts";
 export type {
   IAdminResultsSubmissionInfo,
   IAttempt,
+  ICreateVideoBasedResultDto,
   IEventRankings,
   IEventRecordPairs,
   IFeAttempt,
@@ -24,7 +25,6 @@ export type {
   IUpdateResultDto,
   IUpdateVideoBasedResultDto,
   IVideoBasedResult,
-  IVideoBasedResultDto,
 } from "./interfaces/Result.ts";
 export type { ICutoff, IProceed, IRound, IRoundFormat, ITimeLimit } from "./interfaces/Round.ts";
 export type { IActivity, IRoom, ISchedule, IVenue } from "./interfaces/Schedule.ts";

--- a/client/shared_helpers/types.ts
+++ b/client/shared_helpers/types.ts
@@ -22,7 +22,9 @@ export type {
   IResult,
   IResultsSubmissionInfo,
   IUpdateResultDto,
+  IUpdateVideoBasedResultDto,
   IVideoBasedResult,
+  IVideoBasedResultDto,
 } from "./interfaces/Result.ts";
 export type { ICutoff, IProceed, IRound, IRoundFormat, ITimeLimit } from "./interfaces/Round.ts";
 export type { IActivity, IRoom, ISchedule, IVenue } from "./interfaces/Schedule.ts";

--- a/client/shared_helpers/types.ts
+++ b/client/shared_helpers/types.ts
@@ -21,8 +21,8 @@ export type {
   IRecordPair,
   IResult,
   IResultsSubmissionInfo,
-  ISubmittedResult,
   IUpdateResultDto,
+  IVideoBasedResult,
 } from "./interfaces/Result.ts";
 export type { ICutoff, IProceed, IRound, IRoundFormat, ITimeLimit } from "./interfaces/Round.ts";
 export type { IActivity, IRoom, ISchedule, IVenue } from "./interfaces/Schedule.ts";

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -128,8 +128,6 @@ export class AppService {
 
     if (result) {
       await this.resultsService.updateResult((result as any)._id.toString(), {
-        // TO-DO: MAKE THE updateResult FUNCTION DO THIS AUTOMATICALLY FOR EXTERNALLY-ENTERED RESULTS(?)
-        unapproved: true,
         // TO-DO: ADD PROPER SUPPORT FOR TEAM EVENTS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         personIds: [person.personId],
         attempts,
@@ -158,7 +156,6 @@ export class AppService {
 
       if (result) {
         await this.resultsService.updateResult((result as any)._id.toString(), {
-          unapproved: true,
           personIds: [person.personId],
           attempts: externalResultDto.attempts,
         });

--- a/server/src/helpers/enums.ts
+++ b/server/src/helpers/enums.ts
@@ -8,6 +8,7 @@ export enum LogType {
   GetContest = "get_contest",
   GetModContest = "get_mod_contest",
   CreateContest = "create_contest",
+  OpenRound = 'open_round',
   UpdateContest = "update_contest",
   UpdateContestState = "update_contest_state",
   RemoveContest = "remove_contest",

--- a/server/src/helpers/utilityFunctions.ts
+++ b/server/src/helpers/utilityFunctions.ts
@@ -15,14 +15,14 @@ import {
 import { IUser } from "~/src/helpers/interfaces/User";
 import { formatInTimeZone } from "date-fns-tz";
 import { differenceInDays } from "date-fns";
+import { RoundDocument } from "~/src/models/round.model";
+import { RoundFormat } from "~/shared_helpers/enums";
 
-export const setRoundRankings = async (
-  results: ResultDocument[],
-  ranksWithAverage: boolean,
-): Promise<ResultDocument[]> => {
-  if (results.length === 0) return results;
+export const setRoundRankings = async (round: RoundDocument): Promise<ResultDocument[]> => {
+  if (round.results.length === 0) return round.results;
 
-  const sortedResults = results.sort(ranksWithAverage ? compareAvgs : compareSingles);
+  const ranksWithAverage = [RoundFormat.Mean, RoundFormat.Average].includes(round.format);
+  const sortedResults = round.results.sort(ranksWithAverage ? compareAvgs : compareSingles);
   let prevResult = sortedResults[0];
   let ranking = 1;
 

--- a/server/src/models/result.model.ts
+++ b/server/src/models/result.model.ts
@@ -50,6 +50,9 @@ export class Result {
   regionalAverageRecord?: string;
 
   @Prop()
+  proceeds?: true;
+
+  @Prop()
   videoLink?: string;
 
   @Prop()

--- a/server/src/models/round.model.ts
+++ b/server/src/models/round.model.ts
@@ -63,6 +63,9 @@ export class Round {
 
   @Prop({ type: [{ type: mongoose.Types.ObjectId, ref: "Result" }], required: true })
   results: ResultDocument[];
+
+  @Prop()
+  open?: true;
 }
 
 export type RoundDocument = HydratedDocument<Round>;

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -153,11 +153,12 @@ export class AuthService {
   checkAccessRightsToContest(user: IPartialUser, contest: ContestDocument, allowNotApproved = false) {
     if (contest.state === ContestState.Removed) throw new BadRequestException("This contest has been removed");
 
-    const hasAccessRights = user.roles.includes(Role.Admin) ||
-      (user.roles.includes(Role.Moderator) &&
-        contest.organizers.some((el) => el.personId === user.personId) &&
-        (allowNotApproved || contest.state >= ContestState.Approved) &&
-        contest.state < ContestState.Finished);
+    const hasAccessRights = (allowNotApproved || contest.state >= ContestState.Approved) &&
+      contest.state < ContestState.Published &&
+      (user.roles.includes(Role.Admin) ||
+        (user.roles.includes(Role.Moderator) &&
+          contest.organizers.some((el) => el.personId === user.personId) &&
+          contest.state < ContestState.Finished));
 
     if (!hasAccessRights) {
       this.logger.logAndSave(

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -150,12 +150,13 @@ export class AuthService {
   }
 
   // THE CONTEST MUST ALREADY BE POPULATED!
-  checkAccessRightsToContest(user: IPartialUser, contest: ContestDocument) {
+  checkAccessRightsToContest(user: IPartialUser, contest: ContestDocument, allowNotApproved = false) {
     if (contest.state === ContestState.Removed) throw new BadRequestException("This contest has been removed");
 
     const hasAccessRights = user.roles.includes(Role.Admin) ||
       (user.roles.includes(Role.Moderator) &&
         contest.organizers.some((el) => el.personId === user.personId) &&
+        (allowNotApproved || contest.state >= ContestState.Approved) &&
         contest.state < ContestState.Finished);
 
     if (!hasAccessRights) {

--- a/server/src/modules/contests/contests.controller.ts
+++ b/server/src/modules/contests/contests.controller.ts
@@ -80,6 +80,16 @@ export class ContestsController {
     return await this.service.createContest(contestDto, req.user, saveResults && req.user.roles.includes(Role.Admin));
   }
 
+  // POST /competitions/:competitionId/open-round/:roundId
+  @Post(':competitionId/open-round/:roundId')
+  @UseGuards(AuthenticatedGuard, RolesGuard)
+  @Roles(Role.Admin, Role.Moderator)
+  async openRound(@Param('competitionId') competitionId: string, @Param('roundId') roundId: string) {
+    this.logger.logAndSave(`Opening round ${roundId} for contest ${competitionId}`, LogType.OpenRound);
+
+    return await this.service.openRound(competitionId, roundId);
+  }
+
   // PATCH /competitions/:competitionId
   @Patch(":competitionId")
   @UseGuards(AuthenticatedGuard, RolesGuard)

--- a/server/src/modules/contests/contests.service.ts
+++ b/server/src/modules/contests/contests.service.ts
@@ -197,7 +197,8 @@ export class ContestsService {
   ): Promise<IContestData> {
     const contest = await this.getFullContest(competitionId);
 
-    if (user) this.authService.checkAccessRightsToContest(user, contest);
+    // If the user and the eventId are defined, that means it's for the data entry page
+    if (user) this.authService.checkAccessRightsToContest(user, contest, eventId === undefined);
 
     const activeRecordTypes = await this.recordTypesService.getRecordTypes({ active: true });
     const output: IContestData = {

--- a/server/src/modules/contests/contests.service.ts
+++ b/server/src/modules/contests/contests.service.ts
@@ -360,6 +360,8 @@ export class ContestsService {
       prevRound.open = undefined;
       await prevRound.save();
     }
+
+    return round;
   }
 
   async updateContest(competitionId: string, contestDto: ContestDto, user: IPartialUser) {
@@ -835,15 +837,15 @@ export class ContestsService {
       );
     }
 
-    // Check there are no rounds with no results
+    // Check there are no rounds with fewer than the minimum number of results for a round
     const zeroResultsRound = await this.roundModel
-      .findOne({ competitionId: contest.competitionId, results: { $size: 0 } })
+      .findOne({ competitionId: contest.competitionId, results: { $size: C.minProceedNumber } })
       .exec();
 
     if (zeroResultsRound) {
       const [eventId, roundNumber] = parseRoundId(zeroResultsRound.roundId);
       const event = await this.eventsService.getEventById(eventId);
-      throw new BadRequestException(`${event.name} round ${roundNumber} has no results`);
+      throw new BadRequestException(`${event.name} round ${roundNumber} has fewer than ${C.minProceedNumber} results (see WCA guideline 9q+)`);
     }
 
     // Check there are no incomplete results

--- a/server/src/modules/contests/tests/mocks/round.model.ts
+++ b/server/src/modules/contests/tests/mocks/round.model.ts
@@ -1,6 +1,7 @@
 import { RoundDocument } from "~/src/models/round.model";
 import { IRound } from "@sh/types";
 import { contestsStub } from "../stubs/competitions.stub";
+import { parseRoundId } from "~/shared_helpers/sharedFunctions";
 
 export const RoundModelMock = (): any => ({
   tempOutput: undefined,
@@ -16,7 +17,7 @@ export const RoundModelMock = (): any => ({
     return this;
   },
   findOne({ competitionId, roundId }: { competitionId: string; roundId: string }): RoundDocument {
-    const eventId = roundId.split("-")[0];
+    const [eventId] = parseRoundId(roundId);
 
     this.tempOutput = contestsStub()
       .find((c) => c.competitionId === competitionId)

--- a/server/src/modules/events/events.service.ts
+++ b/server/src/modules/events/events.service.ts
@@ -88,9 +88,7 @@ export class EventsService {
 
   async getEventById(eventId: string): Promise<EventDocument> {
     const event = await this.eventModel.findOne({ eventId }, excl).exec();
-
     if (!event) throw new NotFoundException(`Event with ID ${eventId} not found`);
-
     return event;
   }
 

--- a/server/src/modules/results/dto/create-result.dto.ts
+++ b/server/src/modules/results/dto/create-result.dto.ts
@@ -15,9 +15,9 @@ import { Type } from "class-transformer";
 import { IAttempt } from "@sh/types";
 import C from "@sh/constants";
 import { ContestAttempts } from "~/src/helpers/customValidators";
-import { IResultDto } from "~/shared_helpers/interfaces/Result";
+import { ICreateResultDto } from "~/shared_helpers/interfaces/Result";
 
-export class CreateResultDto implements IResultDto {
+export class CreateResultDto implements ICreateResultDto {
   @IsString()
   @IsNotEmpty()
   eventId: string;

--- a/server/src/modules/results/dto/create-video-based-result.dto.ts
+++ b/server/src/modules/results/dto/create-video-based-result.dto.ts
@@ -4,9 +4,9 @@ import { ArrayMaxSize, ArrayMinSize, IsDateString, IsOptional, IsUrl, Validate, 
 import { IAttempt } from "@sh/types";
 import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from "~/src/helpers/messages";
 import { SubmittedAttempts } from "~/src/helpers/customValidators";
-import { IVideoBasedResultDto } from "~/shared_helpers/types";
+import { ICreateVideoBasedResultDto } from "~/shared_helpers/types";
 
-export class SubmitResultDto extends CreateResultDto implements IVideoBasedResultDto {
+export class CreateVideoBasedResultDto extends CreateResultDto implements ICreateVideoBasedResultDto {
   @IsDateString({}, { message: DATE_VALIDATION_MSG })
   date: Date;
 

--- a/server/src/modules/results/dto/submit-result.dto.ts
+++ b/server/src/modules/results/dto/submit-result.dto.ts
@@ -4,7 +4,7 @@ import { ArrayMaxSize, ArrayMinSize, IsDateString, IsOptional, IsUrl, Validate, 
 import { IAttempt } from "@sh/types";
 import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from "~/src/helpers/messages";
 import { SubmittedAttempts } from "~/src/helpers/customValidators";
-import { IVideoBasedResultDto } from "~/shared_helpers/interfaces/Result";
+import { IVideoBasedResultDto } from "~/shared_helpers/types";
 
 export class SubmitResultDto extends CreateResultDto implements IVideoBasedResultDto {
   @IsDateString({}, { message: DATE_VALIDATION_MSG })

--- a/server/src/modules/results/dto/submit-result.dto.ts
+++ b/server/src/modules/results/dto/submit-result.dto.ts
@@ -4,9 +4,9 @@ import { ArrayMaxSize, ArrayMinSize, IsDateString, IsOptional, IsUrl, Validate, 
 import { IAttempt } from "@sh/types";
 import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from "~/src/helpers/messages";
 import { SubmittedAttempts } from "~/src/helpers/customValidators";
-import { ISubmittedResultDto } from "~/shared_helpers/interfaces/Result";
+import { IVideoBasedResultDto } from "~/shared_helpers/interfaces/Result";
 
-export class SubmitResultDto extends CreateResultDto implements ISubmittedResultDto {
+export class SubmitResultDto extends CreateResultDto implements IVideoBasedResultDto {
   @IsDateString({}, { message: DATE_VALIDATION_MSG })
   date: Date;
 

--- a/server/src/modules/results/dto/update-result.dto.ts
+++ b/server/src/modules/results/dto/update-result.dto.ts
@@ -2,28 +2,15 @@ import { Type } from "class-transformer";
 import {
   ArrayMaxSize,
   ArrayMinSize,
-  IsBoolean,
-  IsDateString,
   IsInt,
-  IsOptional,
-  IsUrl,
   Validate,
   ValidateNested,
 } from "class-validator";
-import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from "~/src/helpers/messages";
 import { AttemptDto } from "./create-result.dto";
 import { IAttempt, IUpdateResultDto } from "@sh/types";
 import { ContestAttempts } from "~/src/helpers/customValidators";
 
 export class UpdateResultDto implements IUpdateResultDto {
-  @IsOptional()
-  @IsDateString({}, { message: DATE_VALIDATION_MSG })
-  date?: Date;
-
-  @IsOptional()
-  @IsBoolean()
-  unapproved?: true;
-
   @ArrayMinSize(1)
   @IsInt({ each: true })
   personIds: number[];
@@ -34,12 +21,4 @@ export class UpdateResultDto implements IUpdateResultDto {
   @ValidateNested({ each: true })
   @Type(() => AttemptDto)
   attempts: IAttempt[];
-
-  @IsOptional()
-  @IsUrl({}, { message: VIDEO_LINK_VALIDATION_MSG })
-  videoLink?: string;
-
-  @IsOptional()
-  @IsUrl({}, { message: DISCUSSION_LINK_VALIDATION_MSG })
-  discussionLink?: string;
 }

--- a/server/src/modules/results/dto/update-video-based-result.dto.ts
+++ b/server/src/modules/results/dto/update-video-based-result.dto.ts
@@ -5,7 +5,7 @@ import {
   IsUrl,
 } from "class-validator";
 import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from "~/src/helpers/messages";
-import { IUpdateVideoBasedResultDto } from "~/shared_helpers/interfaces/Result";
+import { IUpdateVideoBasedResultDto } from "~/shared_helpers/types";
 import { UpdateResultDto } from "~/src/modules/results/dto/update-result.dto";
 
 export class UpdateVideoBasedResultDto extends UpdateResultDto implements IUpdateVideoBasedResultDto {

--- a/server/src/modules/results/dto/update-video-based-result.dto.ts
+++ b/server/src/modules/results/dto/update-video-based-result.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsBoolean,
+  IsDateString,
+  IsOptional,
+  IsUrl,
+} from "class-validator";
+import { DATE_VALIDATION_MSG, DISCUSSION_LINK_VALIDATION_MSG, VIDEO_LINK_VALIDATION_MSG } from "~/src/helpers/messages";
+import { IUpdateVideoBasedResultDto } from "~/shared_helpers/interfaces/Result";
+import { UpdateResultDto } from "~/src/modules/results/dto/update-result.dto";
+
+export class UpdateVideoBasedResultDto extends UpdateResultDto implements IUpdateVideoBasedResultDto {
+  @IsDateString({}, { message: DATE_VALIDATION_MSG })
+  date: Date;
+
+  @IsOptional()
+  @IsBoolean()
+  unapproved?: true;
+
+  @IsUrl({}, { message: VIDEO_LINK_VALIDATION_MSG })
+  videoLink: string;
+
+  @IsOptional()
+  @IsUrl({}, { message: DISCUSSION_LINK_VALIDATION_MSG })
+  discussionLink?: string;
+}

--- a/server/src/modules/results/results.controller.ts
+++ b/server/src/modules/results/results.controller.ts
@@ -19,7 +19,7 @@ import { AuthenticatedGuard } from "~/src/guards/authenticated.guard";
 import { RolesGuard } from "~/src/guards/roles.guard";
 import { Roles } from "~/src/helpers/roles.decorator";
 import { Role } from "@sh/enums";
-import { SubmitResultDto } from "./dto/submit-result.dto";
+import { CreateVideoBasedResultDto } from "./dto/create-video-based-result.dto";
 import { UpdateResultDto } from "./dto/update-result.dto";
 import { LogType } from "~/src/helpers/enums";
 import { getDateOnly } from "@sh/sharedFunctions";
@@ -127,8 +127,8 @@ export class ResultsController {
   @Post()
   @UseGuards(AuthenticatedGuard, RolesGuard)
   @Roles(Role.User)
-  async submitResult(@Body(new ValidationPipe()) submitResultDto: SubmitResultDto, @Request() req: any) {
-    return await this.service.submitResult(submitResultDto, req.user);
+  async createVideoBasedResult(@Body(new ValidationPipe()) createResultDto: CreateVideoBasedResultDto, @Request() req: any) {
+    return await this.service.createVideoBasedResult(createResultDto, req.user);
   }
 
   // PATCH /results/video-based/:id

--- a/server/src/modules/results/results.controller.ts
+++ b/server/src/modules/results/results.controller.ts
@@ -23,6 +23,7 @@ import { SubmitResultDto } from "./dto/submit-result.dto";
 import { UpdateResultDto } from "./dto/update-result.dto";
 import { LogType } from "~/src/helpers/enums";
 import { getDateOnly } from "@sh/sharedFunctions";
+import { UpdateVideoBasedResultDto } from "~/src/modules/results/dto/update-video-based-result.dto";
 
 @Controller("results")
 export class ResultsController {
@@ -110,14 +111,6 @@ export class ResultsController {
     return await this.service.createResult(competitionId, roundId, createResultDto, req.user);
   }
 
-  // POST /results
-  @Post()
-  @UseGuards(AuthenticatedGuard, RolesGuard)
-  @Roles(Role.User)
-  async submitResult(@Body(new ValidationPipe()) submitResultDto: SubmitResultDto, @Request() req: any) {
-    return await this.service.submitResult(submitResultDto, req.user);
-  }
-
   // PATCH /results/:id
   @Patch(":id")
   @UseGuards(AuthenticatedGuard, RolesGuard)
@@ -128,6 +121,22 @@ export class ResultsController {
     @Request() req: any,
   ) {
     return await this.service.updateResult(id, updateResultDto, { user: req.user });
+  }
+
+  // POST /results
+  @Post()
+  @UseGuards(AuthenticatedGuard, RolesGuard)
+  @Roles(Role.User)
+  async submitResult(@Body(new ValidationPipe()) submitResultDto: SubmitResultDto, @Request() req: any) {
+    return await this.service.submitResult(submitResultDto, req.user);
+  }
+
+  // PATCH /results/video-based/:id
+  @Patch("video-based/:id")
+  @UseGuards(AuthenticatedGuard, RolesGuard)
+  @Roles(Role.Admin)
+  async updateVideoBasedResult(@Param("id") id: string, @Body(new ValidationPipe()) updateResultDto: UpdateVideoBasedResultDto) {
+    return await this.service.updateVideoBasedResult(id, updateResultDto);
   }
 
   // DELETE /results/:id

--- a/server/src/modules/results/results.service.ts
+++ b/server/src/modules/results/results.service.ts
@@ -49,7 +49,6 @@ import {
   getFormattedTime,
   getIsCompType,
   getMakesCutoff,
-  getRoundRanksWithAverage,
   setResultRecords,
 } from "@sh/sharedFunctions";
 import { getBaseAvgsFilter, getBaseSinglesFilter, setRankings, setRoundRankings } from "~/src/helpers/utilityFunctions";
@@ -561,7 +560,7 @@ export class ResultsService {
     await this.updateFutureRecords(createdResult, event, recordPairs, { mode: "create" });
 
     round.results.push(createdResult);
-    round.results = await setRoundRankings(round.results, getRoundRanksWithAverage(round.format));
+    round.results = await setRoundRankings(round);
     await round.save();
     await this.updateContestParticipants(contest);
 
@@ -605,7 +604,7 @@ export class ResultsService {
     await this.updateFutureRecords(result, event, recordPairs, { mode: "edit", previousBest, previousAvg });
 
     round.results = round.results.map((r) => (r._id.toString() === resultId ? result : r));
-    round.results = await setRoundRankings(round.results, getRoundRanksWithAverage(round.format));
+    round.results = await setRoundRankings(round);
     round.save();
     await this.updateContestParticipants(contest);
 
@@ -737,7 +736,7 @@ export class ResultsService {
 
     if (contest) {
       round.results = round.results.filter((el) => el._id.toString() !== resultId);
-      round.results = await setRoundRankings(round.results, getRoundRanksWithAverage(round.format));
+      round.results = await setRoundRankings(round);
       round.save();
       await this.updateContestParticipants(contest);
 

--- a/server/src/modules/results/results.service.ts
+++ b/server/src/modules/results/results.service.ts
@@ -522,10 +522,6 @@ export class ResultsService {
     const round = await this.roundModel.findOne({ competitionId, roundId }).populate(resultPopulateOptions).exec();
     if (!round) throw new BadRequestException("Round not found");
     const event = await this.eventsService.getEventById(createResultDto.eventId);
-    const contestEvent = contest.events.find(e => (e.event as any).toString() === event._id.toString());
-    const isFirstRound = contestEvent.rounds.find(r => (r as any).toString() === round._id.toString()) === contestEvent.rounds[0];
-    if (!isFirstRound)
-      throw new BadRequestException("You may not create a new result for a subsequent round. Instead, you should edit an empty result for a competitor who proceeded to this round.");
     if (round.results.find((r) => r.personIds.some((pid) => createResultDto.personIds.includes(pid))))
       throw new BadRequestException("The competitor(s) already has a result in this round");
 

--- a/server/src/modules/results/tests/results.service.spec.ts
+++ b/server/src/modules/results/tests/results.service.spec.ts
@@ -29,7 +29,7 @@ import { RoundModelMock } from "~/src/modules/contests/tests/mocks/round.model";
 import { ContestModelMock } from "~/src/modules/contests/tests/mocks/contest.model";
 import { AuthServiceMock } from "@m/auth/tests/mocks/auth.service";
 import { CreateResultDto } from "../dto/create-result.dto";
-import { SubmitResultDto } from "~/src/modules/results/dto/submit-result.dto";
+import { CreateVideoBasedResultDto } from "~/src/modules/results/dto/create-video-based-result.dto";
 import { resultsStub } from "~/src/modules/results/tests/stubs/results.stub";
 import { eventsStub } from "~/src/modules/events/tests/stubs/events.stub";
 
@@ -184,7 +184,7 @@ describe("ResultsService", () => {
 
     describe("submitResult", () => {
       it("submits new 4x4x4 Blindfolded result", async () => {
-        const newResult: SubmitResultDto = {
+        const newResult: CreateVideoBasedResultDto = {
           eventId: "444bf",
           date: new Date("2024-08-11T00:00:00Z"),
           personIds: [99],
@@ -192,7 +192,7 @@ describe("ResultsService", () => {
           videoLink: "link.com",
         };
 
-        const createdResult = await resultsService.submitResult(newResult, adminUser);
+        const createdResult = await resultsService.createVideoBasedResult(newResult, adminUser);
 
         expect(createdResult.regionalSingleRecord).toBeUndefined();
         expect(createdResult.regionalAverageRecord).toBeUndefined();
@@ -200,7 +200,7 @@ describe("ResultsService", () => {
 
       it("throws an error when there is no video link", async () => {
         await expect(
-          resultsService.submitResult(
+          resultsService.createVideoBasedResult(
             {
               eventId: "444bf",
               date: new Date(),
@@ -215,7 +215,7 @@ describe("ResultsService", () => {
 
       it("throws an error when a non-admin submits a result with an empty video link", async () => {
         await expect(
-          resultsService.submitResult(
+          resultsService.createVideoBasedResult(
             {
               eventId: "444bf",
               date: new Date(),
@@ -230,7 +230,7 @@ describe("ResultsService", () => {
 
       it("throws an error when a non-admin submits a result with unknown time", async () => {
         await expect(
-          resultsService.submitResult(
+          resultsService.createVideoBasedResult(
             {
               eventId: "444bf",
               date: new Date(),


### PR DESCRIPTION
- Only allow entering results for open rounds (`round.open = true`)
- Only allow entering results for a subsequent round if all of the participants proceeded to the round
- Fix bug when entering result, switching the round and switching back
- Don't allow entering results for a contest that hasn't been approved and for published contests
- Add enter mock result feature for development
- Some refactoring